### PR TITLE
Add kernel option for linux-xanmod

### DIFF
--- a/xanados-iso/airootfs/etc/calamares/modules/packagechooser/packagechooser.sh
+++ b/xanados-iso/airootfs/etc/calamares/modules/packagechooser/packagechooser.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+set -e
 
 echo "[INFO] Running XanadOS package chooser..."
 
-# Example logic (to be replaced by actual GUI selections)
-if grep -q "STEAM=yes" /etc/xanados/package-options.conf; then
-    pacman -Sy --noconfirm steam
+CONFIG="/etc/xanados/package-options.conf"
+if [ -f "$CONFIG" ]; then
+# shellcheck source=/etc/xanados/package-options.conf
+    source "$CONFIG"
 fi
+
+case "$KERNEL" in
+    xanmod)
+        pacman -Syu --needed --noconfirm linux-xanmod
+        pacman -Rns --noconfirm linux-zen || true
+        ;;
+    *)
+        pacman -Syu --needed --noconfirm linux-zen
+        pacman -Rns --noconfirm linux-xanmod || true
+        ;;
+esac

--- a/xanados-iso/airootfs/etc/xanados/package-options.conf
+++ b/xanados-iso/airootfs/etc/xanados/package-options.conf
@@ -1,0 +1,1 @@
+KERNEL=zen

--- a/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
+++ b/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+set -e
 
 echo "[INFO] Running XanadOS package chooser..."
 
-# Example logic (to be replaced by actual GUI selections)
-if grep -q "STEAM=yes" /etc/xanados/package-options.conf; then
-    pacman -Sy --noconfirm steam
+CONFIG="/etc/xanados/package-options.conf"
+if [ -f "$CONFIG" ]; then
+# shellcheck source=/etc/xanados/package-options.conf
+    source "$CONFIG"
 fi
+
+case "$KERNEL" in
+    xanmod)
+        pacman -Syu --needed --noconfirm linux-xanmod
+        pacman -Rns --noconfirm linux-zen || true
+        ;;
+    *)
+        pacman -Syu --needed --noconfirm linux-zen
+        pacman -Rns --noconfirm linux-xanmod || true
+        ;;
+esac

--- a/xanados-iso/docs/outline
+++ b/xanados-iso/docs/outline
@@ -29,7 +29,7 @@ Live ISO	Bootable USB environment
 Init System	systemd
 Secure Boot	Optional toggle in Calamares
 Encryption	Optional full disk encryption
-Kernel Options	linux-zen (default), xanmod (optional)
+Kernel Options	linux-zen (default), linux-xanmod (optional)
 
 🎮 Gaming Stack
 Feature	Detail

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -1,5 +1,6 @@
 base
 linux-zen
+linux-xanmod
 linux-firmware
 mkinitcpio
 btrfs-progs


### PR DESCRIPTION
## Summary
- add `linux-xanmod` to the ISO package list
- provide `/etc/xanados/package-options.conf` to select kernel
- update Calamares package chooser to install the requested kernel
- document optional kernel in docs outline

## Testing
- `shellcheck xanados-iso/calamares/modules/packagechooser/packagechooser.sh`
- `shellcheck xanados-iso/airootfs/etc/calamares/modules/packagechooser/packagechooser.sh`
- `python3 -m py_compile xanados-iso/airootfs/etc/xanados/welcome.py` *(fails: unterminated string literal)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e4e48a8832face9ad0e104c5004