### PR TITLE
Add frontend usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,27 @@ This repository contains the archiso profile used to build the XanadOS installat
 3. Run the Calamares installer from the live session to install the system to disk.
 
 For more details see [`xanados-iso/docs/README_XANADOS.md`](xanados-iso/docs/README_XANADOS.md).
+
+## Running the Next.js frontend
+
+The repository also contains a web-based frontend located in `frontend/`. All
+commands below are executed from the repository root and use the `--prefix`
+flag to target the frontend directory.
+
+1. Install dependencies:
+   ```bash
+   npm install --prefix frontend
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev --prefix frontend
+   ```
+3. Lint the codebase:
+   ```bash
+   npm run lint --prefix frontend
+   ```
+4. Generate production builds:
+   ```bash
+   npm run build --prefix frontend
+   ```
+


### PR DESCRIPTION
## Summary
- document commands for running the Next.js frontend

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run type-check` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f76528fd4832f8c8a4ed6f798b294