### PR TITLE
Implement Secure Boot key enrollment

### DIFF
--- a/xanados-iso/airootfs/etc/calamares/scripts/postinstall.sh
+++ b/xanados-iso/airootfs/etc/calamares/scripts/postinstall.sh
@@ -25,7 +25,13 @@ fi
 # Secure Boot setup placeholder
 if [ -f /etc/xanados/secureboot_enabled ]; then
   echo "[XanadOS] Secure Boot enabled, configuring keys..."
-  # TODO: Add key enrollment commands here
+  if command -v sbctl >/dev/null 2>&1; then
+    sbctl create-keys
+    sbctl enroll-keys --yes-this-is-dangerous
+  else
+    echo "[ERROR] sbctl not installed, cannot enroll Secure Boot keys."
+    exit 1
+  fi
 else
   echo "[XanadOS] Secure Boot not enabled."
 fi

--- a/xanados-iso/calamares/scripts/postinstall.sh
+++ b/xanados-iso/calamares/scripts/postinstall.sh
@@ -25,7 +25,13 @@ fi
 # Secure Boot setup placeholder
 if [ -f /etc/xanados/secureboot_enabled ]; then
   echo "[XanadOS] Secure Boot enabled, configuring keys..."
-  # TODO: Add key enrollment commands here
+  if command -v sbctl >/dev/null 2>&1; then
+    sbctl create-keys
+    sbctl enroll-keys --yes-this-is-dangerous
+  else
+    echo "[ERROR] sbctl not installed, cannot enroll Secure Boot keys."
+    exit 1
+  fi
 else
   echo "[XanadOS] Secure Boot not enabled."
 fi


### PR DESCRIPTION
## Summary
- update Calamares `postinstall.sh` scripts
- add sbctl key enrollment when secure boot is enabled

## Testing
- `npm run lint` *(fails: could not find package.json)*
- `npm run type-check` *(fails: could not find package.json)*
- `npm run build` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f765186f4832f939c400cb126679b