### PR TITLE
Default pacman wrapper to use paru

### DIFF
--- a/xanados-iso/airootfs/usr/local/bin/pacman
+++ b/xanados-iso/airootfs/usr/local/bin/pacman
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Wrapper script to prefer paru for package operations
+if command -v paru >/dev/null 2>&1; then
+    exec paru "$@"
+else
+    exec /usr/bin/pacman "$@"
+fi

--- a/xanados-iso/docs/README_XANADOS.md
+++ b/xanados-iso/docs/README_XANADOS.md
@@ -26,4 +26,4 @@ XanadOS is a custom Arch-based Linux distribution tailored for gaming, privacy, 
 
 - `/etc/xanados/` – Scripts and core logic
 - `/etc/skel/.config/autostart/` – First login autostart for Welcome App
-- `/usr/bin/` – Standard binaries (managed via pacman)
+- `/usr/bin/` – Standard binaries (managed via pacman or the paru wrapper)


### PR DESCRIPTION
## Summary
- add a pacman wrapper in `/usr/local/bin` that executes paru when available
- document new pacman/paru wrapper in README_XANADOS

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run type-check` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f740fa740832fb32bf87b81470fc9