### PR TITLE
Fix markdown lint issues

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,7 @@
 # GitHub Workflows
 
-This directory contains workflow configuration files for GitHub Actions. These workflows automate tasks such as testing, linting, and building the project.
+This directory contains workflow configuration files for GitHub Actions.
+These workflows automate tasks such as testing, linting, and building the
+project.
 
 Add additional workflow files (\*.yml) here to extend automation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,12 @@
 # AGENTS.md – Guide for ChatGPT Codex in Arch Linux ISO Projects
 
-_Last updated: 2025-06-03_
+Last updated: 2025-06-03
 
-This document defines development, security, packaging, and build rules for **ChatGPT Codex** when contributing to this Arch Linux-based distribution. Codex may assist in scripting, packaging, testing, ISO creation, and documentation — but must follow all guidance in this file for correctness, reproducibility, and security.
+This document defines development, security, packaging, and build rules for
+**ChatGPT Codex** when contributing to this Arch Linux-based distribution.
+Codex may assist in scripting, packaging, testing, ISO creation, and
+documentation — but must follow all guidance in this file for correctness,
+reproducibility, and security.
 
 ---
 
@@ -57,11 +61,11 @@ Codex may assist with:
 
 ## 🧹 Linting and Formatting Requirements
 
-| File Type      | Linter/Formatter      | Command Example                |
-|----------------|----------------------|-------------------------------|
-| Shell scripts  | shellcheck, shfmt     | `shellcheck script.sh`        |
-| PKGBUILD       | namcap                | `namcap PKGBUILD`             |
-| Markdown       | prettier              | `prettier --check file.md`    |
+| File Type     | Linter/Formatter  | Command Example            |
+| ------------- | ----------------- | -------------------------- |
+| Shell scripts | shellcheck, shfmt | `shellcheck script.sh`     |
+| PKGBUILD      | namcap            | `namcap PKGBUILD`          |
+| Markdown      | prettier          | `prettier --check file.md` |
 
 All code must pass the relevant linters before submission.
 
@@ -92,8 +96,8 @@ Codex must:
 
 Codex-generated PKGBUILD files must:
 
-- Follow Arch packaging standards:  
-  [Arch Wiki: Creating packages](https://wiki.archlinux.org/title/Creating_packages)
+- Follow Arch packaging standards:
+  [Arch Wiki: Creating packages][archpkg]
 - Include all mandatory fields: `pkgname`, `pkgver`, `pkgrel`, `license`, etc.
 - Use `sha256sums` or `validpgpkeys` for source verification
 - Be linted using `namcap` or similar tools
@@ -155,9 +159,11 @@ systemctl list-units --type=service --state=failed
 
 ## 📚 References
 
-- [Arch Wiki: Creating packages](https://wiki.archlinux.org/title/Creating_packages)
+- [Arch Wiki: Creating packages][archpkg]
 - [Arch Wiki: archiso](https://wiki.archlinux.org/title/Archiso)
 - [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks/)
+
+[archpkg]: https://wiki.archlinux.org/title/Creating_packages
 
 ---
 
@@ -172,4 +178,5 @@ systemctl list-units --type=service --state=failed
 
 ## 🗒️ Changelog
 
-- 2025-06-03: Initial version with expanded security, linting, and workflow guidance.
+- 2025-06-03: Initial version with expanded security, linting, and workflow
+  guidance.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # XanadOS
 
-XanadOS is a cyberpunk-inspired Linux distribution based on Arch Linux. It aims to deliver a gaming focused experience while keeping the system minimal and privacy oriented. A custom PyQt5 "Welcome App" lets you choose between Gaming, Minimal or full Recommended setups as soon as you boot the live environment.
+XanadOS is a cyberpunk-inspired Linux distribution based on Arch Linux.
+It aims to deliver a gaming-focused experience while keeping the system minimal
+and privacy oriented. A custom PyQt5 "Welcome App" lets you choose between
+Gaming, Minimal or full Recommended setups as soon as you boot the live
+environment.
 
 ## Features
 
@@ -12,7 +16,8 @@ XanadOS is a cyberpunk-inspired Linux distribution based on Arch Linux. It aims 
 
 ## Repository layout
 
-This repository contains the archiso profile as well as supporting directories used to build XanadOS.
+This repository contains the archiso profile as well as supporting
+directories used to build XanadOS.
 
 - `xanados-iso/` – archiso profile and build scripts
 - `xanados-iso/calamares/` – Calamares installer configuration
@@ -30,19 +35,27 @@ This repository contains the archiso profile as well as supporting directories u
 ## Building the ISO
 
 1. Install the `archiso` package:
+
    ```bash
    sudo pacman -S archiso
    ```
+
 2. Clone this repository and enter the profile directory:
+
    ```bash
    git clone <repository-url>
    cd xanados/xanados-iso
    ```
-3. Run `mkarchiso` to create the image (output will be placed in the `out/` directory):
+
+3. Run `mkarchiso` to create the image.
+   Output will be placed in the `out/` directory:
+
    ```bash
    sudo mkarchiso -v -o out .
    ```
+
 4. Flash the resulting ISO to a USB drive:
+
    ```bash
    sudo dd if=out/xanados-*.iso of=/dev/sdX bs=4M status=progress && sync
    ```
@@ -50,10 +63,15 @@ This repository contains the archiso profile as well as supporting directories u
 ## Installing XanadOS
 
 1. Boot your machine from the USB stick.
-2. On first login the **Welcome App** appears. Pick Gaming, Minimal or Recommended to install the desired packages. Logs are saved to `/tmp/welcome.log` and the autostart entry is provided by `/etc/xanados/welcome.desktop`.
-3. Run the Calamares installer from the live session to install the system to disk.
+2. On first login the **Welcome App** appears. Pick Gaming, Minimal or
+   Recommended to install the desired packages. Logs are saved to
+   `/tmp/welcome.log` and the autostart entry is provided by
+   `/etc/xanados/welcome.desktop`.
+3. Run the Calamares installer from the live session to install the
+   system to disk.
 
-For more details see [`xanados-iso/docs/README_XANADOS.md`](xanados-iso/docs/README_XANADOS.md).
+For more details see
+[`xanados-iso/docs/README_XANADOS.md`](xanados-iso/docs/README_XANADOS.md).
 
 ## Running the Next.js frontend
 
@@ -62,19 +80,27 @@ commands below are executed from the repository root and use the `--prefix`
 flag to target the frontend directory.
 
 1. Install dependencies:
+
    ```bash
    npm install --prefix frontend
    ```
+
 2. Start the development server:
+
    ```bash
    npm run dev --prefix frontend
    ```
+
 3. Lint the codebase:
+
    ```bash
    npm run lint --prefix frontend
    ```
+
    ESLint rules are defined in `frontend/.eslintrc.json`.
+
 4. Generate production builds:
+
    ```bash
    npm run build --prefix frontend
    ```


### PR DESCRIPTION
## Summary
- address markdownlint warnings for README
- fix AGENTS formatting
- rewrap .github workflows docs

## Testing
- `prettier --check README.md AGENTS.md .github/workflows/README.md`
- `npm run lint --prefix frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684039962f0c832fa87b0524af95b6ba