### PR TITLE
Fix docs README line length

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 This directory stores project documentation.
 
-Additional AGENTS guides have been imported to help understand the `system_maint.sh` reference:
+Additional AGENTS guides have been imported to help
+understand the `system_maint.sh` reference:
 
 - [AGENTS_CI.md](AGENTS_CI.md)
 - [AGENTS_SECURITY.md](AGENTS_SECURITY.md)


### PR DESCRIPTION
## Summary
- fix docs README line length to satisfy Markdown lint

## Testing
- `npx prettier --check docs/README.md`
- `npx markdownlint-cli2 docs/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684079e020c0832f8a81a229e129eb50