### PR TITLE
Remove linux-xanmod references

### DIFF
--- a/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
+++ b/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
@@ -9,13 +9,5 @@ if [ -f "$CONFIG" ]; then
 	source "$CONFIG"
 fi
 
-case "$KERNEL" in
-xanmod)
-	pacman -Syu --needed --noconfirm linux-xanmod
-	pacman -Rns --noconfirm linux-zen || true
-	;;
-*)
-	pacman -Syu --needed --noconfirm linux-zen
-	pacman -Rns --noconfirm linux-xanmod || true
-	;;
-esac
+pacman -Syu --needed --noconfirm linux-zen
+pacman -Rns --noconfirm linux-xanmod || true

--- a/xanados-iso/docs/outline
+++ b/xanados-iso/docs/outline
@@ -29,7 +29,7 @@ Live ISO	Bootable USB environment
 Init System	systemd
 Secure Boot	Optional toggle in Calamares
 Encryption	Optional full disk encryption
-Kernel Options	linux-zen (default), linux-xanmod (optional)
+Kernel	linux-zen
 
 🎮 Gaming Stack
 Feature	Detail

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -1,6 +1,5 @@
 base
 linux-zen
-linux-xanmod
 linux-firmware
 mkinitcpio
 btrfs-progs


### PR DESCRIPTION
## Summary
- drop `linux-xanmod` from ISO package list
- clean up docs about kernel options
- simplify Calamares packagechooser module

## Testing
- `shellcheck -x xanados-iso/calamares/modules/packagechooser/packagechooser.sh`
- `shfmt -w xanados-iso/calamares/modules/packagechooser/packagechooser.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840cd5d7094832f8c60722e51c8e117