### PR TITLE
Remove obsolete packages and fix installer script

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -5,9 +5,12 @@ exec > >(tee -a "$LOGFILE") 2>&1
 
 echo "[XanadOS] Starting Full Recommended Stack installation at $(date)"
 
-if ! pacman -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper spotify-launcher; then
-	echo "[ERROR] Full Recommended Stack installation failed."
-	exit 1
+if ! pacman -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper; then
+        echo "[ERROR] Full Recommended Stack installation failed."
+        exit 1
 fi
+
+echo "[XanadOS] Note: Spotify is available from the AUR as 'spotify-launcher'."
+echo "Install it manually after setting up an AUR helper."
 
 echo "[XanadOS] Full package set installed successfully at $(date)"

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -60,7 +60,6 @@ gamemode
 retroarch
 vlc
 gwenview
-spotify-launcher
 p7zip
 file-roller
 base-devel
@@ -69,7 +68,6 @@ wget
 openssh
 dosfstools
 ntfs-3g
-exfat-utils
 fuse3
 gvfs
 gvfs-smb
@@ -88,7 +86,6 @@ rsync
 fd
 tmux
 ttf-liberation
-wireless_tools
 openvpn
 wireguard-tools
 gst-plugins-base


### PR DESCRIPTION
## Summary
- remove `spotify-launcher`, `exfat-utils` and `wireless_tools`
- update install_recommended.sh to no longer try to install spotify from pacman
- note in script that Spotify is available through the AUR

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh`
- `prettier --check README.md docs/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6840d2a1acfc832fa4a9cefb01b9a6d3