### PR TITLE
Fix ShellCheck warnings

### DIFF
--- a/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
+++ b/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
@@ -6,6 +6,7 @@ echo "[INFO] Running XanadOS package chooser..."
 CONFIG="/etc/xanados/package-options.conf"
 if [ -f "$CONFIG" ]; then
 	# shellcheck source=/etc/xanados/package-options.conf
+	# shellcheck disable=SC1091
 	source "$CONFIG"
 fi
 

--- a/xanados-iso/profiledef.sh
+++ b/xanados-iso/profiledef.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 # ISO label and versioning
 iso_name="xanados"


### PR DESCRIPTION
## Summary
- silence SC2034 warnings for ISO profile variables
- silence SC1091 warning in packagechooser module
- normalize shell formatting

## Testing
- `shellcheck xanados-iso/profiledef.sh xanados-iso/calamares/modules/packagechooser/packagechooser.sh`
- `shfmt -d xanados-iso/profiledef.sh xanados-iso/calamares/modules/packagechooser/packagechooser.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840d4ca6df8832f94d0b3004556b1a0