### PR TITLE
Switch to Paru for package operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ directories used to build XanadOS.
 
 ## Building the ISO
 
-1. Install the `archiso` package:
+1. Install the `archiso` package using Paru:
 
    ```bash
-   sudo pacman -S archiso
+   paru -S archiso
    ```
 
 2. Clone this repository and enter the profile directory:

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -5,7 +5,7 @@ exec > >(tee -a "$LOGFILE") 2>&1
 
 echo "[XanadOS] Starting Gaming Stack installation at $(date)"
 
-if ! pacman -Syu --needed --noconfirm steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks; then
+if ! paru -Syu --needed --noconfirm steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks; then
 	echo "[ERROR] Gaming Stack installation failed."
 	exit 1
 fi

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
@@ -5,7 +5,7 @@ exec > >(tee -a "$LOGFILE") 2>&1
 
 echo "[XanadOS] Starting Minimal environment installation at $(date)"
 
-if ! pacman -Syu --needed --noconfirm plasma-desktop dolphin konsole networkmanager; then
+if ! paru -Syu --needed --noconfirm plasma-desktop dolphin konsole networkmanager; then
 	echo "[ERROR] Minimal environment installation failed."
 	exit 1
 fi

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -5,9 +5,9 @@ exec > >(tee -a "$LOGFILE") 2>&1
 
 echo "[XanadOS] Starting Full Recommended Stack installation at $(date)"
 
-if ! pacman -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper; then
-        echo "[ERROR] Full Recommended Stack installation failed."
-        exit 1
+if ! paru -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper; then
+	echo "[ERROR] Full Recommended Stack installation failed."
+	exit 1
 fi
 
 echo "[XanadOS] Note: Spotify is available from the AUR as 'spotify-launcher'."

--- a/xanados-iso/airootfs/etc/xanados/welcome.py
+++ b/xanados-iso/airootfs/etc/xanados/welcome.py
@@ -215,8 +215,8 @@ class WelcomeApp(QtWidgets.QWidget):
             return
         self.log_output.append("[INFO] Running post-install maintenance tasks...")
         commands = [
-            "sudo pacman -Syu --noconfirm",
-            "sudo paccache -r",
+            "paru -Syu --noconfirm",
+            "paccache -r",
             "systemctl status NetworkManager",
             "systemctl status chronyd",
             "journalctl -b -1 --no-pager | tail -n 50",

--- a/xanados-iso/docs/README_XANADOS.md
+++ b/xanados-iso/docs/README_XANADOS.md
@@ -29,4 +29,4 @@ Featured — during first boot.
 
 - `/etc/xanados/` – Scripts and core logic
 - `/etc/skel/.config/autostart/` – First login autostart for Welcome App
-- `/usr/bin/` – Standard binaries (managed via pacman or the paru wrapper)
+- `/usr/bin/` – Standard binaries managed via **paru** (pacman wrapper)

--- a/xanados-iso/docs/outline
+++ b/xanados-iso/docs/outline
@@ -22,54 +22,54 @@ Maintain modular logic, so nothing is forced
 
 📦 Features & Capabilities Summary
 🖥️ System Base
-Feature	Detail
-Base	Arch Linux
-Installer	Calamares (GUI)
-Live ISO	Bootable USB environment
-Init System	systemd
-Secure Boot	Optional toggle in Calamares
-Encryption	Optional full disk encryption
-Kernel	linux-zen
+Feature Detail
+Base Arch Linux
+Installer Calamares (GUI)
+Live ISO Bootable USB environment
+Init System systemd
+Secure Boot Optional toggle in Calamares
+Encryption Optional full disk encryption
+Kernel linux-zen
 
 🎮 Gaming Stack
-Feature	Detail
-Game Launchers	Steam, Lutris, Heroic, RetroDeck
-Runtime Tools	MangoHud, vkBasalt, Gamemode, Wine, Proton-GE, DXVK, vkd3d
-Performance	zram, preload, nohang, earlyoom
-CPU Tuning	auto-cpufreq, cpupower-gui
-Cleanup Tools	Custom gameloop shader/cache cleaner
-NTFS Support	ntfs-3g, automounted with full permissions
+Feature Detail
+Game Launchers Steam, Lutris, Heroic, RetroDeck
+Runtime Tools MangoHud, vkBasalt, Gamemode, Wine, Proton-GE, DXVK, vkd3d
+Performance zram, preload, nohang, earlyoom
+CPU Tuning auto-cpufreq, cpupower-gui
+Cleanup Tools Custom gameloop shader/cache cleaner
+NTFS Support ntfs-3g, automounted with full permissions
 
 🔐 Security
-Feature	Detail
-AppArmor	Enabled
-Firejail	Preconfigured for browser isolation
-Flatpak Sandboxing	Fully integrated with Flatseal
-Secure Boot	Optional during install
-Tor Browser	Available via Welcome App
-Firewall	UFW active by default
+Feature Detail
+AppArmor Enabled
+Firejail Preconfigured for browser isolation
+Flatpak Sandboxing Fully integrated with Flatseal
+Secure Boot Optional during install
+Tor Browser Available via Welcome App
+Firewall UFW active by default
 
 💻 User Interface & Experience
-Feature	Detail
-Desktop Environment	KDE Plasma
-Theming	Cyberpunk + Retro CRT + Dark Mode
-Terminal	Alacritty (default)
-System Monitors	btop, Conky
-Bootloader	Custom GRUB theme
-Boot Splash	Plymouth animation (ASCII style)
-Login Screen	SDDM (themed to match)
-File Manager	Dolphin
-Flatpak Integration	Discover preconfigured with Flathub
-GUI Package Options	Octopi (pacman/AUR), Bauh (multi-store)
+Feature Detail
+Desktop Environment KDE Plasma
+Theming Cyberpunk + Retro CRT + Dark Mode
+Terminal Alacritty (default)
+System Monitors btop, Conky
+Bootloader Custom GRUB theme
+Boot Splash Plymouth animation (ASCII style)
+Login Screen SDDM (themed to match)
+File Manager Dolphin
+Flatpak Integration Discover preconfigured with Flathub
+GUI Package Options Octopi (paru/AUR), Bauh (multi-store)
 
 🧰 Welcome App (PyQt5)
-Functionality	Detail
-App Loader	Optional installs by category (Gaming, Tools, Browsers)
-Browser Selector	Brave, LibreWolf, Ungoogled Chromium, GNOME Web, Tor
-Presets	Gaming Mode, Minimal Install, Install All
-Secure Boot State	Checks /etc/xanados/secureboot_enabled
-Appearance Picker	Wallpaper/icon themes
-Runs on First Boot	Can be re-launched from menu
+Functionality Detail
+App Loader Optional installs by category (Gaming, Tools, Browsers)
+Browser Selector Brave, LibreWolf, Ungoogled Chromium, GNOME Web, Tor
+Presets Gaming Mode, Minimal Install, Install All
+Secure Boot State Checks /etc/xanados/secureboot_enabled
+Appearance Picker Wallpaper/icon themes
+Runs on First Boot Can be re-launched from menu
 
 📁 Expected File Structure: xanados-iso
 Here’s the high-level structure from the uploaded ISO tarball:
@@ -78,31 +78,31 @@ bash
 Copy
 Edit
 xanados-iso/
-├── airootfs/                       # Root filesystem for live ISO
-│   ├── etc/
-│   │   ├── systemd/
-│   │   ├── xdg/
-│   │   ├── xanados/               # Flags and config (e.g. secureboot_enabled)
-│   │   ├── mkinitcpio.conf.d/
-│   │   └── pacman.d/
-│   ├── root/.gnupg/
-│   ├── root/.automated_script.sh
-│   ├── usr/share/
-│   └── etc/skel/
-├── calamares/                     # Installer configuration
-│   ├── branding/xanados/
-│   │   ├── style.qss              # Custom style
-│   │   └── services.conf
-│   ├── modules/
-│   │   └── secureboot-toggle/
-│   └── settings.conf
-├── grub/                          # GRUB bootloader config
-│   └── grub.cfg
-├── efiboot/                       # EFI boot entries
-├── syslinux/                      # PXE boot configs
-│   └── archiso_pxe.cfg
-├── packages.x86_64                # Full package list
-├── bootstrap_packages.x86_64      # Minimal bootstrap list
+├── airootfs/ # Root filesystem for live ISO
+│ ├── etc/
+│ │ ├── systemd/
+│ │ ├── xdg/
+│ │ ├── xanados/ # Flags and config (e.g. secureboot_enabled)
+│ │ ├── mkinitcpio.conf.d/
+│ │ └── pacman.d/
+│ ├── root/.gnupg/
+│ ├── root/.automated_script.sh
+│ ├── usr/share/
+│ └── etc/skel/
+├── calamares/ # Installer configuration
+│ ├── branding/xanados/
+│ │ ├── style.qss # Custom style
+│ │ └── services.conf
+│ ├── modules/
+│ │ └── secureboot-toggle/
+│ └── settings.conf
+├── grub/ # GRUB bootloader config
+│ └── grub.cfg
+├── efiboot/ # EFI boot entries
+├── syslinux/ # PXE boot configs
+│ └── archiso_pxe.cfg
+├── packages.x86_64 # Full package list
+├── bootstrap_packages.x86_64 # Minimal bootstrap list
 
 🧠 What This ISO Does
 Boots into a fully themed KDE Plasma Live Environment


### PR DESCRIPTION
## Summary
- use `paru` instead of `pacman` in docs and install scripts
- update Welcome App maintenance commands
- note Paru usage in the ISO documentation
- remove `sudo` prefix from `paru` commands as requested

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh`
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh`
- `shfmt -w xanados-iso/airootfs/etc/xanados/scripts/*.sh`
- `npx prettier -w README.md xanados-iso/docs/README_XANADOS.md`
- `npx prettier --parser markdown -w xanados-iso/docs/outline`


------
https://chatgpt.com/codex/tasks/task_e_6840d6729438832fb31b057db633ee3c