### PR TITLE
Fix ISO build by installing sudo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install archiso
         run: pacman -Syu --noconfirm archiso
+      - name: Install sudo
+        run: pacman -Syu --noconfirm sudo
       - name: Build ISO
         run: bash scripts/build_iso.sh


### PR DESCRIPTION
## Summary
- update workflow to install `sudo` before running the build script

## Testing
- `~/.local/bin/yamllint -c .yamllint.yml .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_6841ab1d791c832fb4ba30c1f4e8bf56