### PR TITLE
Fix build prerequisites and markdown lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,12 @@
 # .github/workflows/build.yml
+---
 name: Build
 
-on:
+"on":
   push:
-    branches: [main]
-  workflow_dispatch:
+    branches:
+      - main
+  workflow_dispatch: {}
 
 jobs:
   build:
@@ -18,5 +20,7 @@ jobs:
         run: pacman -Syu --noconfirm archiso
       - name: Install sudo
         run: pacman -Syu --noconfirm sudo
+      - name: Install grub
+        run: pacman -Syu --noconfirm grub
       - name: Build ISO
         run: bash scripts/build_iso.sh

--- a/scripts/build_iso.sh
+++ b/scripts/build_iso.sh
@@ -5,14 +5,22 @@ LOG_DIR="$(cd "$(dirname "$0")/.." && pwd)/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/iso-build.log"
 
+# Ensure required tools are installed
+for cmd in mkarchiso grub-install; do
+	if ! command -v "$cmd" >/dev/null 2>&1; then
+		echo "Error: required command '$cmd' not found. Please install the corresponding package." >&2
+		exit 1
+	fi
+done
+
 # Rotate log if larger than 10MB
 if [ -f "$LOG_FILE" ] && [ "$(stat -c%s "$LOG_FILE")" -gt 10485760 ]; then
-  mv "$LOG_FILE" "${LOG_FILE}.$(date -u +%Y%m%d%H%M%S)"
+	mv "$LOG_FILE" "${LOG_FILE}.$(date -u +%Y%m%d%H%M%S)"
 fi
 
 {
-  echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Starting ISO build"
-  cd "$(dirname "$0")/../xanados-iso"
-  sudo mkarchiso -v -o out .
-  echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Build finished"
+	echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Starting ISO build"
+	cd "$(dirname "$0")/../xanados-iso"
+	sudo mkarchiso -v -o out .
+	echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Build finished"
 } | tee "$LOG_FILE"

--- a/xanados-iso/docs/todo-28-may-25.md
+++ b/xanados-iso/docs/todo-28-may-25.md
@@ -1,4 +1,4 @@
-XanadOS Finalization Checklist – Pre-Deployment
+# XanadOS Finalization Checklist – Pre-Deployment
 
 🔧 1. Theming & Visuals
 🎨 SDDM Login Screen


### PR DESCRIPTION
## Summary
- check for mkarchiso and grub in `build_iso.sh`
- install grub in build workflow
- conform `build.yml` to yamllint rules
- add missing heading to ISO TODO doc

## Testing
- `shellcheck scripts/build_iso.sh`
- `shfmt -d scripts/build_iso.sh`
- `yamllint .github/workflows/build.yml`
- `prettier -c xanados-iso/docs/todo-28-may-25.md`


------
https://chatgpt.com/codex/tasks/task_e_6841b3cd21a0832f9413210efdd4df74