### PR TITLE
Improve ISO build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ directories used to build XanadOS.
    sudo dd if=out/xanados-*.iso of=/dev/sdX bs=4M status=progress && sync
    ```
 
+### Building in Docker
+
+If `mkarchiso` isn't available locally, run the build inside a Docker
+container using the provided helper script:
+
+```bash
+bash scripts/docker_build_iso.sh
+```
+
+This launches an Arch Linux container, installs the required packages, and
+produces the ISO in `out/`. Logs are saved to `logs/docker-iso-build.log`.
+
 ## Installing XanadOS
 
 1. Boot your machine from the USB stick.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,1 +1,5 @@
 # Scripts
+
+- `build_iso.sh` – Build the ISO on a system with `mkarchiso` installed.
+- `docker_build_iso.sh` – Run the ISO build inside a Docker container. Useful
+  if `mkarchiso` isn't available locally.

--- a/scripts/docker_build_iso.sh
+++ b/scripts/docker_build_iso.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$REPO_ROOT/logs"
+LOG_FILE="$LOG_DIR/docker-iso-build.log"
+mkdir -p "$LOG_DIR"
+
+# Rotate log if larger than 10MB
+if [ -f "$LOG_FILE" ] && [ "$(stat -c%s "$LOG_FILE")" -gt 10485760 ]; then
+	mv "$LOG_FILE" "${LOG_FILE}.$(date -u +%Y%m%d%H%M%S)"
+fi
+
+{
+	echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Starting Docker ISO build"
+	docker run --rm \
+		--privileged \
+		-v "$REPO_ROOT":/repo \
+		--workdir /repo/xanados-iso \
+		archlinux:latest \
+		bash -c 'pacman -Syu --noconfirm archiso grub && mkarchiso -v -o /repo/out .'
+	echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Build finished"
+} | tee "$LOG_FILE"


### PR DESCRIPTION
## Summary
- add docker_build_iso.sh to build ISO inside a Docker container
- document Docker build script in README and scripts/README

## Testing
- `shellcheck scripts/docker_build_iso.sh`
- `shfmt -w scripts/docker_build_iso.sh`
- `prettier --write README.md scripts/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6841b9645030832fb604dd0a1ed8186b