### PR TITLE
Fix package list and add check script

### DIFF
--- a/scripts/check_packages.py
+++ b/scripts/check_packages.py
@@ -1,0 +1,44 @@
+import requests
+import warnings
+from urllib.parse import quote_plus
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+import json
+import sys
+from pathlib import Path
+
+packages_file = Path('xanados-iso/packages.x86_64')
+if not packages_file.exists():
+    print('packages file not found')
+    sys.exit(1)
+
+with packages_file.open() as f:
+    packages = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+
+seen = set()
+duplicates = []
+missing_packages = []
+results = {}
+
+for pkg in packages:
+    if pkg in seen:
+        duplicates.append(pkg)
+        continue
+    seen.add(pkg)
+    arch_url = f'https://archlinux.org/packages/search/json/?name={quote_plus(pkg)}'
+    res = requests.get(arch_url, timeout=10, verify=False)
+    if res.ok and res.json().get('results'):
+        results[pkg] = 'arch'
+        continue
+    aur_url = f'https://aur.archlinux.org/rpc/?v=5&type=info&arg={quote_plus(pkg)}'
+    res = requests.get(aur_url, timeout=10, verify=False)
+    if res.ok and res.json().get('resultcount', 0) > 0:
+        results[pkg] = 'aur'
+    else:
+        results[pkg] = 'missing'
+        missing_packages.append(pkg)
+
+print('Duplicate packages:', duplicates)
+print('Missing packages:', missing_packages)
+print('Summary:')
+for pkg, src in results.items():
+    print(f'{pkg}: {src}')

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -60,7 +60,7 @@ gamemode
 retroarch
 vlc
 gwenview
-p7zip
+7-zip
 file-roller
 base-devel
 cmake


### PR DESCRIPTION
## Summary
- add `scripts/check_packages.py` helper to verify ISO package list against Arch repos and the AUR
- replace deprecated `p7zip` with `7-zip` in `packages.x86_64`

## Testing
- `python3 scripts/check_packages.py` *(fails: InsecureRequestWarning and network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2204068832fa576f1bfd5aca32b