### PR TITLE
Fix missing package handling in build_iso

### DIFF
--- a/scripts/build_iso.sh
+++ b/scripts/build_iso.sh
@@ -20,9 +20,12 @@ if [ ! -d "$REPO_DIR" ]; then
 	exit 1
 fi
 
-if compgen -G "$REPO_DIR"/*.pkg.tar.zst >/dev/null; then
-	repo-add "$REPO_DIR/xanados.db.tar.gz" "$REPO_DIR"/*.pkg.tar.zst
+if ! compgen -G "$REPO_DIR"/*.pkg.tar.zst >/dev/null; then
+        echo "Error: No package files (*.pkg.tar.zst) found in '$REPO_DIR'. Please add the required packages." >&2
+        exit 1
 fi
+
+repo-add "$REPO_DIR/xanados.db.tar.gz" "$REPO_DIR"/*.pkg.tar.zst
 
 # Rotate log if larger than 10MB
 if [ -f "$LOG_FILE" ] && [ "$(stat -c%s "$LOG_FILE")" -gt 10485760 ]; then


### PR DESCRIPTION
## Summary
- fail fast if packages missing in scripts/build_iso.sh

## Testing
- `shellcheck scripts/build_iso.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841c7594dec832fbce3e09db6dbe2db