### PR TITLE
Refactor package build for root safety

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -8,7 +8,9 @@ The resulting `*.pkg.tar.zst` files are copied into
 `packages/repo` and added to the local repository used by the ISO
 build.
 
-Use standard Arch tooling when authoring `PKGBUILD`s:
+Use standard Arch tooling when authoring `PKGBUILD`s. `scripts/build_packages.sh`
+installs any missing build dependencies (including `namcap`) using `sudo pacman`
+so the script itself can run unprivileged for most operations:
 
 ```bash
 namcap PKGBUILD

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -7,6 +7,49 @@ REPO_DIR="$PKG_ROOT/repo"
 
 mkdir -p "$REPO_DIR"
 
+# Run command as root, using sudo if needed
+as_root() {
+  if ((EUID == 0)); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+# Run command as the dedicated build user when executed as root
+as_builduser() {
+  if ((EUID == 0)); then
+    sudo -Hu builduser "$@"
+  else
+    "$@"
+  fi
+}
+
+if ((EUID == 0)); then
+  # Create build user if missing
+  if ! id builduser >/dev/null 2>&1; then
+    as_root useradd -m builduser
+  fi
+fi
+
+install_deps() {
+  local dir="$1"
+  pushd "$dir" >/dev/null
+  # shellcheck disable=SC1091
+  source ./PKGBUILD
+  local all_deps=("${depends[@]}")
+  all_deps+=("${makedepends[@]}")
+  if [ ${#all_deps[@]} -gt 0 ]; then
+    local missing
+    missing=$(pacman -T "${all_deps[@]}" || true)
+    if [ -n "$missing" ]; then
+      echo "Installing missing dependencies: $missing"
+      as_root pacman -Sy --needed --noconfirm "$missing"
+    fi
+  fi
+  popd >/dev/null
+}
+
 build_pkg() {
   local dir="$1"
   if [ ! -f "$dir/PKGBUILD" ]; then
@@ -14,10 +57,15 @@ build_pkg() {
   fi
   echo "## Building $(basename "$dir")"
   pushd "$dir" >/dev/null
-  namcap PKGBUILD || true
-  makepkg --verifysource --noconfirm
-  updpkgsums
-  makepkg -sf --noconfirm
+  if ! command -v namcap >/dev/null 2>&1; then
+    echo "Installing namcap" >&2
+    as_root pacman -Sy --needed --noconfirm namcap
+  fi
+  as_builduser namcap PKGBUILD || true
+  as_builduser makepkg --verifysource --noconfirm
+  as_builduser updpkgsums
+  install_deps "$dir"
+  as_builduser makepkg -f --noconfirm
   local pkgfile
   pkgfile=$(find . -maxdepth 1 -name '*.pkg.tar.zst' -print -quit)
   if [ -n "${pkgfile:-}" ]; then


### PR DESCRIPTION
## Summary
- avoid running makepkg as root by using a builduser
- install namcap automatically when missing
- update package docs about dependency handling

## Testing
- `shellcheck scripts/build_packages.sh`
- `shfmt -d -i 2 scripts/build_packages.sh`
- `npx prettier --check docs/packages.md`
- `npx bats tests/test_build_iso.bats`

------
https://chatgpt.com/codex/tasks/task_e_6842c4e5e600832f8413ad9d47cb4c23