### PR TITLE
Add heading and rewrap lines in calamares README

### DIFF
--- a/packages/calamares/README.md
+++ b/packages/calamares/README.md
@@ -1,2 +1,8 @@
-Do to the use of the `-DFEATURE_no_direct_extern_access=ON` flag in upstream `qt6-base`, I had to take a very non-standard approatch to make this work for QT6 builds.
-If upstream drops the `-DFEATURE_no_direct_extern_access=ON` flag at any point, mark this package as out of date so I can remove the non-standard logic accordingly.
+# Calamares
+
+Due to the use of the `-DFEATURE_no_direct_extern_access=ON` flag in upstream
+`qt6-base`, I had to take a very non-standard approach to make this work for
+QT6 builds.
+If upstream drops the `-DFEATURE_no_direct_extern_access=ON` flag at any point,
+mark this package as out of date so I can remove the non-standard logic
+accordingly.


### PR DESCRIPTION
## Summary
- add a level‑1 heading to `packages/calamares/README.md`
- wrap existing sentences to 80 characters or less

## Testing
- `npx prettier --check packages/calamares/README.md`
- `npx markdownlint-cli2 packages/calamares/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6842cf397f50832f8bc00eaa9f583c00