### PR TITLE
Fix calamares permissions in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,7 @@ jobs:
         run: pacman -Syu --noconfirm sudo
       - name: Install grub
         run: pacman -Syu --noconfirm grub
+      - name: Fix permissions for calamares
+        run: sudo chown -R builduser:builduser packages/calamares
       - name: Build ISO
         run: bash scripts/build_iso.sh


### PR DESCRIPTION
## Summary
- ensure `packages/calamares` is owned by the build user before compiling

## Testing
- `yamllint .github/workflows/build.yml`
- `shellcheck scripts/build_packages.sh`
- `shellcheck scripts/build_iso.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842cf3d5278832f97567b543e74fcd8