### PR TITLE
Fix long lines in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # XanadOS
 
-[![Build Status](https://github.com/asafelobotomy/xanados/actions/workflows/build.yml/badge.svg)](https://github.com/asafelobotomy/xanados/actions)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Build Status][build-img]][build-url]
+[![License: GPL v3][license-img]][license-url]
+[![PRs Welcome][pr-img]][pr-url]
 
 ## Table of Contents
 
@@ -171,3 +171,10 @@ Contributions are welcome! Please see
 
 This project is licensed under the GNU General Public License v3.0.
 See the [LICENSE](LICENSE) file for details.
+
+[build-img]: https://github.com/asafelobotomy/xanados/actions/workflows/build.yml/badge.svg
+[build-url]: https://github.com/asafelobotomy/xanados/actions
+[license-img]: https://img.shields.io/badge/License-GPLv3-blue.svg
+[license-url]: LICENSE
+[pr-img]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
+[pr-url]: CONTRIBUTING.md

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,3 +1,4 @@
 # Configs
 
-System configuration snippets used by the ISO. This includes systemd units, pacman hooks and mkinitcpio config files.
+System configuration snippets used by the ISO. This includes systemd units,
+pacman hooks and mkinitcpio config files.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,4 @@
 # XanadOS Frontend
 
-This directory contains the Next.js based interface for ISO downloads and updates. Run `npm install` and `npm run dev` here to start the frontend.
+This directory contains the Next.js based interface for ISO downloads and
+updates. Run `npm install` and `npm run dev` here to start the frontend.

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,3 +1,4 @@
 # Logs
 
-Build scripts save output here for troubleshooting. ISO and package builds append logs with timestamps. Old logs may be rotated after 30 days.
+Build scripts save output here for troubleshooting. ISO and package builds
+append logs with timestamps. Old logs may be rotated after 30 days.


### PR DESCRIPTION
## Summary
- rewrap long lines in README files
- switch README badge links to reference style

## Testing
- `npx markdownlint-cli README.md logs/README.md configs/README.md frontend/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6842f344abcc832f80535728b045eb2a