### PR TITLE
Fix Docker build pacman path

### DIFF
--- a/xanados-iso/pacman.conf
+++ b/xanados-iso/pacman.conf
@@ -13,7 +13,9 @@ LocalFileSigLevel = Optional
 
 [xanados]
 SigLevel = Optional TrustAll
-Server = file:///workspace/xanados/packages/repo
+# Use /repo when building in Docker; locally this path resolves via the
+# repository root mount in scripts/build_iso.sh
+Server = file:///repo/packages/repo
 
 [core]
 Include = /etc/pacman.d/mirrorlist


### PR DESCRIPTION
## Summary
- fix path to custom package repo in pacman.conf for Docker builds

## Testing
- `bats tests`
- `shellcheck scripts/build_iso.sh`
- `shellcheck scripts/docker_build_iso.sh`
- `shellcheck scripts/build_packages.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842fc7a567c832f87f4e8dca99dc880