### PR TITLE
Fix build perms and markdown lint

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,3 +1,10 @@
 # GitHub Workflows
 
-This directory contains workflow configuration files for GitHub Actions. The workflows automate linting and other tasks. Workflows include `build.yml`, `shellcheck.yml`, `markdownlint.yml` and others that keep the repository safe and consistent. Additional files extend coverage for tests, formatting, security scans, building and releases.
+This directory contains workflow configuration files for GitHub Actions. These
+workflows automate linting and other tasks.
+
+Workflows include `build.yml`, `shellcheck.yml`, `markdownlint.yml` and others
+that keep the repository safe and consistent.
+
+Additional files extend coverage for tests, formatting, security scans,
+building and releases.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo groupadd -f builduser
           sudo useradd -m -g builduser builduser || true
-      - name: Fix permissions for calamares
-        run: sudo chown -R builduser:builduser packages/calamares
+      - name: Grant write access to build directory
+        run: sudo chown -R builduser:builduser packages
       - name: Build ISO
         run: bash scripts/build_iso.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 1. [Project Scope & Directory Structure](#-project-scope--directory-structure)
 2. [Forbidden Actions & Security](#-forbidden-actions--security)
 3. [Contributor Responsibilities](#-contributor-responsibilities)
-4. [Pre-task checks to perform:](#-Pre-task-checks-to-perform)
+4. [Pre-task checks to perform](#-pre-task-checks-to-perform)
 5. [Example Workflow: Adding a Package](#-example-workflow-adding-a-package)
 6. [Linting & Formatting](#-linting--formatting)
 7. [Security and Compliance](#-security-and-compliance)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to XanadOS
 
-Thank you for your interest in contributing! This project follows guidelines summarized from [AGENTS.md](AGENTS.md).
+Thank you for your interest in contributing!
+This project follows guidelines summarized from
+[AGENTS.md](AGENTS.md).
 
 ## Project Scope
 
@@ -61,4 +63,5 @@ Avoid modifying files outside these areas unless specifically reviewed.
 
 ## Suggesting Improvements
 
-Open a pull request or GitHub issue with a clear summary and rationale. Include test results and follow the guidelines above.
+Open a pull request or GitHub issue with a clear summary and rationale.
+Include test results and follow the guidelines above.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 # Docs
 
 This directory stores project documentation.
-The files here describe how to build custom packages, configure the ISO profile, and maintain development workflows. See `xanados-iso/docs/` for live environment details.
+The files here describe how to build custom packages and configure the ISO
+profile.
+They also cover how to maintain development workflows.
+See `xanados-iso/docs/` for live environment details.
 See [packages.md](packages.md) for details on building custom packages.

--- a/failed_checks_and_errors/Checklist.md
+++ b/failed_checks_and_errors/Checklist.md
@@ -27,11 +27,17 @@ Use this file to track issues reported in [errors1.md](errors1.md).
 - [x] Add static makedepends to calamares PKGBUILD
 - [x] Fix write permission for $BUILDDIR in CI
 - [x] Create builduser user/group before chown
+- [x] Grant write access to packages directory in CI workflow
+- [x] Fix markdownlint errors across repository
+- [x] Reviewed systemd warnings; safe to ignore in CI
 
 ===
 
 ## Changelog
 
 - 2025-06-07: Clarified checklist instructions and formatted with Prettier.
-- 2025-06-06: Created machine-id during package build to silence systemd tmpfiles warnings.
+- 2025-06-06: Created machine-id during package build to silence systemd
+  tmpfiles warnings.
 - 2025-06-06: Added builduser creation step in CI.
+- 2025-06-08: Added tasks for package permissions, markdown lint cleanup and
+  systemd warning review.

--- a/failed_checks_and_errors/errors1.md
+++ b/failed_checks_and_errors/errors1.md
@@ -1,12 +1,18 @@
 # High-Level Build Review for `asafelobotomy/xanados`
 
-_Last updated: 2025-06-06_
+Last updated: 2025-06-06
 
 ---
 
 ## Summary
 
-This report covers the most recent build and lint runs for the repository. It details critical and recurring issues in the CI/CD pipeline, markdown/documentation, and system permissions. The information is based on the 10 latest failed workflow runs out of a total of 177. For a full history of results, visit the [GitHub Actions page](https://github.com/asafelobotomy/xanados/actions/runs?branch=main&status=failure&per_page=5&sort=updated).
+This report covers the most recent build and lint runs for the repository.
+It details critical and recurring issues in the CI/CD pipeline,
+markdown/documentation and system permissions.
+The information is based on the 10 latest failed workflow runs out of a total of
+177.
+For a full history of results, visit the
+[GitHub Actions page][gha-runs].
 
 ---
 
@@ -15,35 +21,51 @@ This report covers the most recent build and lint runs for the repository. It de
 ### 1. **Build Directory Permissions**
 
 **Error Message:**
-```
+
+```text
 ==> ERROR: You do not have write permission for the directory $BUILDDIR (/__w/xanados/xanados/packages/bats).
 Aborting...
 Process completed with exit code 11.
-```
+```sh
 
 **Implications:**
-- The build process is aborted before completion, leading to incomplete builds and failed CI checks.
-- This error appears in every recent build run, indicating a persistent misconfiguration in the workflow environment.
+
+- The build process is aborted before completion, leading to incomplete builds
+  and failed CI checks.
+- This error appears in every recent build run, indicating a persistent
+  misconfiguration in the workflow environment.
 
 **Root Cause:**
-- The runner user does not have write access to the `$BUILDDIR` (specifically, `/__w/xanados/xanados/packages/bats`).
+
+- The runner user does not have write access to the `$BUILDDIR`
+  (specifically, `/__w/xanados/xanados/packages/bats`).
 
 **Solution Steps:**
-1. **Check Workflow File**: In `.github/workflows/build.yml`, ensure that before starting the build, the runner user either owns or has write permission to `$BUILDDIR`.
-2. **Add a Step to Fix Permissions** (Example for a typical Ubuntu runner):
+
+1. **Check Workflow File**: In `.github/workflows/build.yml`, ensure that before
+   starting the build, the runner user either owns or has write permission to
+   `$BUILDDIR`.
+1. **Add a Step to Fix Permissions** (Example for a typical Ubuntu runner):
+
    ```yaml
    - name: Ensure write access to build directory
      run: sudo chown -R $(whoami) $__w/xanados/xanados/packages/bats
    ```
+
    Or, for a more generic fix:
+
    ```yaml
    - name: Fix build directory permissions
      run: sudo chmod -R u+w $__w/xanados/xanados/packages
    ```
-3. **Verify Directory Creation**: If the directory does not exist beforehand, add a step to create it.
+
+1. **Verify Directory Creation**: If the directory does not exist beforehand,
+   add a step to create it.
 
 **Potential Future Risks:**
-- If permissions are not consistently set across all jobs/steps, future contributors may encounter the same error.
+
+- If permissions are not consistently set across all jobs/steps,
+  future contributors may encounter the same error.
 - Directory paths hardcoded in workflows may break if the repo or runner setup changes.
 
 ---
@@ -51,7 +73,10 @@ Process completed with exit code 11.
 ### 2. **Markdown Lint Errors**
 
 **Summary:**
-- All recent runs of the `Markdown Lint` workflow are failing due to multiple markdown style violations, including line length, invalid link fragments, missing blank lines, and improper code block formatting.
+
+- All recent runs of the `Markdown Lint` workflow are failing due to multiple
+  markdown style violations. Issues include line length, invalid link fragments,
+  missing blank lines and improper code block formatting.
 - Errors are found in various files, including:
   - `.github/workflows/README.md`
   - `AGENTS.md`
@@ -62,6 +87,7 @@ Process completed with exit code 11.
   - `xanados-iso/docs/suggestions.md`
 
 **Common Error Types & Examples:**
+
 - **Line length exceeded (MD013)**: Lines longer than 80 characters.
 - **Invalid link fragments (MD051)**: Incorrect anchor links (e.g., case mismatch).
 - **Missing blank lines around headings/lists (MD022/MD032)**.
@@ -70,20 +96,26 @@ Process completed with exit code 11.
 - **Multiple consecutive blank lines (MD012)**.
 
 **Solution Steps:**
+
 1. **Automated Fixing**:
    - Use `markdownlint-cli2` auto-fix if possible:
-     ```
-     npx markdownlint-cli2 "**/*.md" --fix
-     ```
+
+    ```sh
+    npx markdownlint-cli2 "**/*.md" --fix
+    ```
+
 2. **Manual Fixes**:
-   - Review the specific errors in the workflow logs for which lines and files need attention.
+   - Review the specific errors in the workflow logs to determine which lines
+     and files need attention.
    - Ensure all lines are ≤ 80 characters, except where readability is compromised.
    - Update heading anchors to match expected formats and cases.
    - Surround all headings, lists, and code fences with the required blank lines.
    - Make sure the first line in every markdown file is a top-level heading (`#`).
 
 **Potential Future Risks:**
-- New documentation or contributors may introduce violations if no pre-commit or CI lint is enforced.
+
+- New documentation or contributors may introduce violations if no pre-commit
+  or CI lint is enforced.
 - Inconsistent markdown style can lower documentation quality and accessibility.
 
 ---
@@ -91,22 +123,33 @@ Process completed with exit code 11.
 ### 3. **System/Runner Environment Issues**
 
 **Observed Messages:**
+
 - `Skipped: Current root is not booted.`
-- `/usr/lib/tmpfiles.d/journal-nocow.conf:26: Failed to resolve specifier: uninitialized /etc/ detected, skipping. All rules containing unresolvable specifiers will be skipped.`
+- `/usr/lib/tmpfiles.d/journal-nocow.conf:26: Failed to resolve specifier:
+  uninitialized /etc/ detected, skipping. All rules containing unresolvable
+  specifiers will be skipped.`
 
 **Implications:**
-- These warnings indicate the runner is in a minimal or containerized environment. They do not directly cause the build to fail but may hint at deeper system configuration issues.
+
+- These warnings indicate the runner is in a minimal or containerized
+  environment.
+  They do not directly cause the build to fail but may hint at deeper system
+  configuration issues.
 
 **Solution Steps:**
-- **Generally Safe to Ignore** unless your build explicitly requires systemd or writes to those parts of the filesystem.
-- If you need more complex system services, consider using a VM-based runner or a Docker container with additional privileges.
+
+- **Generally Safe to Ignore** unless your build explicitly requires systemd or
+  writes to those parts of the filesystem.
+- If you need more complex system services, consider using a VM-based runner or
+  a Docker container with additional privileges.
 
 ---
 
 ## Incomplete Results Notice
 
 - **Only 10 out of 177 failed workflow runs are included here.**
-- For a complete picture, review all failures and history in the [GitHub Actions UI](https://github.com/asafelobotomy/xanados/actions/runs?branch=main&status=failure&per_page=5&sort=updated).
+- For a complete picture, review all failures and history in the
+  [GitHub Actions UI][gha-runs].
 
 ---
 
@@ -115,32 +158,41 @@ Process completed with exit code 11.
 1. **Fix Directory Permissions in CI** immediately to unblock builds.
 2. **Enforce Markdown Lint Checks** locally before PRs (add instructions to `CONTRIBUTING.md`).
 3. **Automate Lint Fixes** where possible.
-4. **Review System Environment** only if your build needs full systemd or persistent system-level changes.
+4. **Review System Environment** only if your build needs full systemd or
+   persistent system-level changes.
 
 ---
 
 ## Useful Links
 
-- [Latest Failed Build Run](https://github.com/asafelobotomy/xanados/actions/runs/15493406563)
-- [Latest Failed Markdown Lint Run](https://github.com/asafelobotomy/xanados/actions/runs/15493241229)
-- [All Failed Workflow Runs](https://github.com/asafelobotomy/xanados/actions/runs?branch=main&status=failure&per_page=5&sort=updated)
+- [Latest Failed Build Run][build-run]
+- [Latest Failed Markdown Lint Run][lint-run]
+- [All Failed Workflow Runs][all-runs]
 
 ---
 
 ## Appendix: Example Errors
 
-**Permission Error**
+### Permission Error
+
 ```sh
 ==> ERROR: You do not have write permission for the directory $BUILDDIR (/__w/xanados/xanados/packages/bats).
 Aborting...
-```
+```text
 
-**Markdown Lint Error**
-```
-AGENTS.md:15:4 MD051/link-fragments Link fragments should be valid [Expected: #-pre-task-checks-to-perform; Actual: #-Pre-task-checks-to-perform]
+### Markdown Lint Error
+
+```text
+AGENTS.md:15:4 MD051/link-fragments Link fragments should be valid
+  [Expected: #-pre-task-checks-to-perform; Actual: #-Pre-task-checks-to-perform]
 CONTRIBUTING.md:3:81 MD013/line-length Line length [Expected: 80; Actual: 116]
 ```
 
 ---
 
-*Prepared by Copilot Build Review*
+Prepared by Copilot Build Review
+
+[build-run]: https://github.com/asafelobotomy/xanados/actions/runs/15493406563
+[lint-run]: https://github.com/asafelobotomy/xanados/actions/runs/15493241229
+[all-runs]: https://github.com/asafelobotomy/xanados/actions
+[gha-runs]: https://github.com/asafelobotomy/xanados/actions

--- a/xanados-iso/docs/suggestions.md
+++ b/xanados-iso/docs/suggestions.md
@@ -1,7 +1,9 @@
-🧪 Optional Upgrades & Enhancements for XanadOS
+# Optional Upgrades & Enhancements for XanadOS
+
 🎨 UI / Visual Experience
 Feature Description
-🖼️ Animated Wallpapers (via Komorebi or Plasma plugins) Add high-quality animated backgrounds
+🖼️ Animated Wallpapers (via Komorebi or Plasma plugins)
+Add high-quality animated backgrounds
 🧩 Global Theme Manager Custom app or Plasma theme preset switcher
 🧠 Real-Time Theme Sync Sync GRUB, Plymouth, SDDM, Plasma from one panel
 🧱 UI Scaling Toggle Allow 100%, 125%, 150% scaling presets for HiDPI displays


### PR DESCRIPTION
## Summary
- give CI runner write access to the packages directory
- clean up markdown-lint issues
- document that systemd warnings are harmless
- add checklist entries for new CI tasks

## Testing
- `npx -y markdownlint-cli2 "**/*.md"`
- `pytest -q` *(no tests ran)*
- `bats tests/test_build_iso.bats` *(fails: command not found)*
- `shellcheck scripts/build_iso.sh scripts/build_packages.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843019b2cd4832f9cc6efbb06cbb0e3