### PR TITLE
Ensure Bats installed during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
         run: pacman -Syu --noconfirm sudo
       - name: Install grub
         run: pacman -Syu --noconfirm grub
+      - name: Install bats
+        run: pacman -Syu --noconfirm bats
       - name: Create build user
         run: |
           sudo groupadd -f builduser

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,5 @@ profile.
 They also cover how to maintain development workflows.
 See `xanados-iso/docs/` for live environment details.
 See [packages.md](packages.md) for details on building custom packages.
+The local `bats` package is built automatically when running
+`scripts/build_packages.sh` so that shell tests can run offline.

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -76,6 +76,10 @@ build_pkg() {
   pkgfile=$(find . -maxdepth 1 -name '*.pkg.tar.zst' -print -quit)
   if [ -n "${pkgfile:-}" ]; then
     mv "$pkgfile" "$REPO_DIR/"
+    if [[ $(basename "$dir") == "bats" ]]; then
+      echo "Installing $(basename "$pkgfile")"
+      as_root pacman -U --noconfirm "$REPO_DIR/$(basename "$pkgfile")"
+    fi
   fi
   popd >/dev/null
 }

--- a/scripts/docker_build_iso.sh
+++ b/scripts/docker_build_iso.sh
@@ -18,6 +18,6 @@ fi
     -v "$REPO_ROOT":/repo \
     --workdir /repo/xanados-iso \
     archlinux:latest \
-    bash -c 'pacman -Syu --noconfirm archiso grub && mkarchiso -v -o /repo/out .'
+    bash -c 'pacman -Syu --noconfirm archiso grub bats && mkarchiso -v -o /repo/out .'
   echo "### $(date -u '+%Y-%m-%d %H:%M:%S UTC') Build finished"
 } | tee "$LOG_FILE"


### PR DESCRIPTION
## Summary
- automatically install Bats when building packages
- install Bats in Docker ISO build
- install Bats in GitHub build workflow
- document offline Bats package in docs

## Testing
- `shellcheck scripts/build_packages.sh scripts/build_iso.sh scripts/docker_build_iso.sh`
- `shfmt -d -i 2 scripts/build_packages.sh scripts/build_iso.sh scripts/docker_build_iso.sh`
- `npx prettier --check README.md docs/README.md docs/packages.md CONTRIBUTING.md`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6843051c0424832fab0aec08e038a39b