### PR TITLE
Fix README bullet path reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ directories used to build XanadOS.
 - [`xanados-iso/calamares/`](xanados-iso/calamares/) – Calamares configs
 - [`xanados-iso/airootfs/`](xanados-iso/airootfs/) – live environment rootfs
 - [`xanados-iso/packages.x86_64`](xanados-iso/packages.x86_64) – package list
-- [`bootstrap_pkgs`](xanados-iso/bootstrap_packages.x86_64) – minimal pkgs
+- [`bootstrap_packages.x86_64`](xanados-iso/bootstrap_packages.x86_64) – minimal pkgs
 - [`xanados-iso/docs/`](xanados-iso/docs/) – additional documentation
 - [`packages/`](packages/) – custom PKGBUILDs
 - [`scripts/`](scripts/) – automation scripts


### PR DESCRIPTION
## Summary
- sync README bullet text with linked file path

## Testing
- `npm list --depth=0`
- `bats tests` *(fails: command not found)*
- `prettier --check .` *(fails: issues found)*
- `atom --check **/*.md` *(fails: command not found)*
- `shellcheck scripts/*.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843097daa70832fbc075dd13e37f0ae