### PR TITLE
Update CI checklist

### DIFF
--- a/failed_checks_and_errors/Checklist.md
+++ b/failed_checks_and_errors/Checklist.md
@@ -8,28 +8,16 @@ Use this file to track issues reported in [errors1.md](errors1.md).
 4. When you resolve an item, check it off and
    add a note under **CHANGELOG** with todays date.
 
-## Markdown Lint
-
-- [x] AGENTS.md uses a bare URL (MD034)
-- [x] packages/calamares/README.md line 1 exceeds 80 characters (MD013)
-- [x] packages/calamares/README.md missing top-level heading (MD041)
-- [x] packages/calamares/README.md line 2 exceeds 80 characters (MD013)
-- [x] README.md lines 45–47 exceed 80 characters (MD013)
-
-## Proselint
-
-- [x] AGENTS.md line 136 should use curly quotes
-- [x] AGENTS.md line 141 has too many exclamation marks
-
 ## Build
 
-- [x] CI warnings about unbooted root and journal specifier
-- [x] Add static makedepends to calamares PKGBUILD
-- [x] Fix write permission for $BUILDDIR in CI
-- [x] Create builduser user/group before chown
-- [x] Grant write access to packages directory in CI workflow
-- [x] Fix markdownlint errors across repository
-- [x] Reviewed systemd warnings; safe to ignore in CI
+- [ ] Install `debugedit` and `fakeroot` packages in the CI workflow.
+- [ ] Investigate warnings about an unbooted root and journal specifier.
+
+## Markdown Lint
+
+- [ ] Break long lines at 80 characters or update `.markdownlint.yml`.
+- [ ] Ensure all files start with a top‑level heading.
+- [ ] Replace bare URLs with proper Markdown links.
 
 ===
 
@@ -41,3 +29,4 @@ Use this file to track issues reported in [errors1.md](errors1.md).
 - 2025-06-06: Added builduser creation step in CI.
 - 2025-06-06: Added tasks for package permissions, markdown lint cleanup and
   systemd warning review.
+- 2025-06-06: Reset checklist with new build and markdown lint issues.

--- a/failed_checks_and_errors/errors1.md
+++ b/failed_checks_and_errors/errors1.md
@@ -13,6 +13,7 @@ This report summarizes the recent workflow failures in the repository, their cau
 **Commit:** `4873d39ab276679ce0ff0fb4e23e1c4bbae73832`
 
 ### Main Errors
+
 - `ERROR: Cannot find the debugedit binary required for including source files in debug packages.`
 - `ERROR: Cannot find the fakeroot binary.`
 - Warnings about "Skipped: Current root is not booted." and "Failed to resolve specifier: uninitialized /etc/ detected, skipping."
@@ -77,26 +78,27 @@ This report summarizes the recent workflow failures in the repository, their cau
 
 ## Quick Summary Table
 
-| Workflow              | Main Error(s)                           | Resolution                                   |
-|-----------------------|-----------------------------------------|----------------------------------------------|
-| Build                 | Missing `debugedit`, `fakeroot`         | Install with `pacman -Sy --noconfirm debugedit fakeroot` |
-|                       | Container/root warnings                 | Typically safe to ignore in CI               |
-| Markdown Lint         | Line too long (MD013)                   | Break lines at 80 characters or adjust config|
-|                       | No top-level heading (MD041)            | Add `# Heading` to start of each file        |
-|                       | Bare URLs (MD034)                       | Use `[text](url)` links                      |
+| Workflow      | Main Error(s)                   | Resolution                                               |
+| ------------- | ------------------------------- | -------------------------------------------------------- |
+| Build         | Missing `debugedit`, `fakeroot` | Install with `pacman -Sy --noconfirm debugedit fakeroot` |
+|               | Container/root warnings         | Typically safe to ignore in CI                           |
+| Markdown Lint | Line too long (MD013)           | Break lines at 80 characters or adjust config            |
+|               | No top-level heading (MD041)    | Add `# Heading` to start of each file                    |
+|               | Bare URLs (MD034)               | Use `[text](url)` links                                  |
 
 ---
 
 ## References
 
-- [Build workflow failure log (main)](https://github.com/asafelobotomy/xanados/actions/runs/15494723405)  
-- [Markdown lint failure log (main)](https://github.com/asafelobotomy/xanados/actions/runs/15494723418)  
-- [Build workflow failure log (PR)](https://github.com/asafelobotomy/xanados/actions/runs/15494717855)  
-- [Markdown lint failure log (PR)](https://github.com/asafelobotomy/xanados/actions/runs/15494717933)  
+- [Build workflow failure log (main)](https://github.com/asafelobotomy/xanados/actions/runs/15494723405)
+- [Markdown lint failure log (main)](https://github.com/asafelobotomy/xanados/actions/runs/15494723418)
+- [Build workflow failure log (PR)](https://github.com/asafelobotomy/xanados/actions/runs/15494717855)
+- [Markdown lint failure log (PR)](https://github.com/asafelobotomy/xanados/actions/runs/15494717933)
 
 ---
 
 **Next Steps:**
+
 1. Update your workflow YAML to ensure all required build tools (`debugedit`, `fakeroot`) are installed before building packages.
 2. Refactor Markdown files to comply with lint rules, or update `.markdownlint.yml` if you want to change the policy.
 3. Re-run workflows to confirm all issues are resolved.


### PR DESCRIPTION
## Summary
- update checklist with new build and markdown lint issues
- run Prettier on errors1.md

## Testing
- `npm list --depth=0`
- `prettier --check .`
- `atom --check **/*.md` *(fails: command not found)*
- `shellcheck scripts/*.sh` *(fails: command not found)*
- `bats tests` *(fails: command not found)*
- `pip install -r requirements.txt`
- `python scripts/check_packages.py`


------
https://chatgpt.com/codex/tasks/task_e_68433fb2cde8832fbab5cbfe6b7a1aeb