### PR TITLE
Add error log update workflow

### DIFF
--- a/.github/workflows/update_errors.yml
+++ b/.github/workflows/update_errors.yml
@@ -1,0 +1,44 @@
+# .github/workflows/update_errors.yml
+name: Update Error Log
+
+on:
+  workflow_run:
+    workflows:
+      - Build
+      - ShellCheck
+      - Markdown Lint
+      - Code Formatting
+      - security
+      - release
+    types:
+      - completed
+
+jobs:
+  update-errors:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+      - name: Download logs
+        run: |
+          gh run download ${{ github.event.workflow_run.id }} -D logs
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+      - name: Update error log
+        run: bash scripts/update_error_log.sh logs
+      - name: Commit changes
+        run: |
+          git config user.name "xanados-bot"
+          git config user.email "xanados-bot@example.com"
+          git add failed_checks_and_errors/errors1.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update CI error summary"
+            git push
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/scripts/update_error_log.sh
+++ b/scripts/update_error_log.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="${1:-$REPO_ROOT/logs}"
+ERROR_FILE="$REPO_ROOT/failed_checks_and_errors/errors1.md"
+
+SHA="${GITHUB_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD)}"
+RUN_URL=""
+if [ -n "${GITHUB_SERVER_URL:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ]; then
+  RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+fi
+
+TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# Gather error lines from log files
+ERROR_LINES=""
+if ls "$LOG_DIR"/*.log >/dev/null 2>&1; then
+  ERROR_LINES=$(grep -i "error" "$LOG_DIR"/*.log | tail -n 20 || true)
+fi
+
+if [ -z "$ERROR_LINES" ]; then
+  echo "No error lines found" >&2
+  exit 0
+fi
+
+{
+  echo "\n---"
+  echo "\n### CI Failure - $TIMESTAMP"
+  echo ""
+  echo "**Commit:** \`$SHA\`"
+  if [ -n "$RUN_URL" ]; then
+    echo "**Run:** [$GITHUB_RUN_ID]($RUN_URL)"
+  fi
+  echo ""
+  echo '\```text'
+  echo "$ERROR_LINES"
+  echo '\```'
+} >> "$ERROR_FILE"

--- a/tests/test_build_iso.bats
+++ b/tests/test_build_iso.bats
@@ -15,3 +15,11 @@
 @test "docker_build_iso.sh is executable" {
   [ -x scripts/docker_build_iso.sh ]
 }
+
+@test "update_error_log.sh exists" {
+  [ -f scripts/update_error_log.sh ]
+}
+
+@test "update_error_log.sh is executable" {
+  [ -x scripts/update_error_log.sh ]
+}


### PR DESCRIPTION
## Summary
- add `update_error_log.sh` script for summarizing CI logs
- run script via new `update_errors.yml` workflow when other workflows fail
- verify new script in bats tests

## Testing
- `npm list --depth=0`
- `bats tests`
- `prettier --check .`
- `atom --check **/*.md` *(fails: command not found)*
- `shellcheck scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_684346eef5c8832fbd7b6b9370a2564d