### PR TITLE
Document ignoring systemd tmpfiles warnings

### DIFF
--- a/failed_checks_and_errors/Checklist.md
+++ b/failed_checks_and_errors/Checklist.md
@@ -15,7 +15,9 @@ Follow these steps whenever you work with this checklist:
 ## Build
 
 - [ ] Install `debugedit` and `fakeroot` packages in the CI workflow.
-- [ ] Investigate warnings about an unbooted root and journal specifier.
+- [x] Investigate warnings about an unbooted root and journal specifier.
+      These messages appear in CI when `/etc` is not fully initialized and
+      can be ignored unless they cause the build to fail.
 
 ## Markdown Lint
 
@@ -34,3 +36,4 @@ Follow these steps whenever you work with this checklist:
 - 2025-06-06: Added tasks for package permissions, markdown lint cleanup and
   systemd warning review.
 - 2025-06-06: Reset checklist with new build and markdown lint issues.
+- 2025-06-06: Noted that systemd tmpfiles warnings are safe to ignore in CI.


### PR DESCRIPTION
## Summary
- note that systemd tmpfiles warnings can be ignored

## Testing
- `npm list --depth=0`
- `bats tests`
- `npx prettier --check .`
- `yes | npx markdownlint-cli **/*.md`
- `shellcheck scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_68434e205f94832f8f3ffcc720620d9d