### PR TITLE
Fix markdown lint tasks

### DIFF
--- a/failed_checks_and_errors/Checklist.md
+++ b/failed_checks_and_errors/Checklist.md
@@ -22,8 +22,8 @@ Follow these steps whenever you work with this checklist:
 ## Markdown Lint
 
 - [ ] Break long lines at 80 characters or update `.markdownlint.yml`.
-- [ ] Ensure all files start with a top‑level heading.
-- [ ] Replace bare URLs with proper Markdown links.
+- [x] Ensure all files start with a top‑level heading.
+- [x] Replace bare URLs with proper Markdown links.
 
 ===
 
@@ -37,3 +37,4 @@ Follow these steps whenever you work with this checklist:
   systemd warning review.
 - 2025-06-06: Reset checklist with new build and markdown lint issues.
 - 2025-06-06: Noted that systemd tmpfiles warnings are safe to ignore in CI.
+- 2025-06-06: Completed Markdown heading and link fixes.


### PR DESCRIPTION
## Summary
- check off completed markdown lint tasks in the failure checklist

## Testing
- `npm list --depth=0`
- `bats tests`
- `npx prettier --check .`
- `npx atom --check **/*.md` *(fails: could not determine executable)*
- `shellcheck scripts/*.sh`
- `python scripts/check_packages.py`

------
https://chatgpt.com/codex/tasks/task_e_6843567d72e4832fb4aa964fea064f2e