### PR TITLE
Add custom gaming package selection and security/performance tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+*.bak
+__pycache__/
+package.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# XanadOS ISO
+
+This repository contains the build files for the XanadOS ISO. The package list has been updated to include optional security and performance tools. Gaming packages are now installed on demand rather than as part of the base system.
+
+## Security packages added
+- fail2ban
+- nmap
+- wireshark-qt
+- clamav
+- rkhunter
+
+## Performance packages added
+- tlp
+- thermald
+- cpupower
+- irqbalance
+- preload
+- earlyoom
+
+`paru` is now included for install scripts.
+
+## Custom gaming installation
+From the welcome application you can select individual gaming packages to install. The installer passes the chosen packages to `install_gaming.sh`, which also accepts packages via command line:
+
+```bash
+install_gaming.sh steam lutris heroic-games-launcher
+```
+
+You can also supply a file containing package names:
+
+```bash
+install_gaming.sh -f /path/to/pkglist.txt
+```
+
+If no packages are specified, a default set will be installed.

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -1,13 +1,52 @@
 #!/bin/bash
 set -e
+
 LOGFILE="/tmp/welcome_install.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 
 echo "[XanadOS] Starting Gaming Stack installation at $(date)"
 
-if ! paru -Syu --needed --noconfirm steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks; then
-	echo "[ERROR] Gaming Stack installation failed."
-	exit 1
+usage() {
+    echo "Usage: $0 [-f package_file] [packages...]" >&2
+}
+
+PACKAGES=()
+while getopts ":f:h" opt; do
+    case $opt in
+        f)
+            if [[ -f $OPTARG ]]; then
+                while IFS= read -r line; do
+                    [[ -z $line || $line =~ ^# ]] && continue
+                    PACKAGES+=("$line")
+                done < "$OPTARG"
+            else
+                echo "[ERROR] Package file not found: $OPTARG" >&2
+                exit 1
+            fi
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        ?)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
+if [[ $# -gt 0 ]]; then
+    PACKAGES+=("$@")
+fi
+
+if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+    PACKAGES=(steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks)
+fi
+
+if ! paru -Syu --needed --noconfirm "${PACKAGES[@]}"; then
+    echo "[ERROR] Gaming Stack installation failed."
+    exit 1
 fi
 
 echo "[XanadOS] Gaming tools installed successfully at $(date)"

--- a/xanados-iso/airootfs/etc/xanados/welcome.py
+++ b/xanados-iso/airootfs/etc/xanados/welcome.py
@@ -18,7 +18,12 @@ class InstallerThread(QtCore.QThread):
 
     def run(self):
         success = True
-        for script in self.scripts:
+        for entry in self.scripts:
+            if isinstance(entry, (list, tuple)):
+                script, *args = entry
+            else:
+                script, args = entry, []
+
             if not self._is_running:
                 self.progress.emit("[INFO] Installation cancelled by user.")
                 success = False
@@ -27,10 +32,11 @@ class InstallerThread(QtCore.QThread):
                 self.progress.emit(f"[ERROR] Script not found: {script}")
                 success = False
                 break
-            self.progress.emit(f"▶ Executing: {script}")
+            display = " ".join([script] + args)
+            self.progress.emit(f"▶ Executing: {display}")
             try:
                 process = subprocess.Popen(
-                    ["bash", script],
+                    ["bash", script] + args,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     universal_newlines=True,
@@ -107,7 +113,7 @@ class WelcomeApp(QtWidgets.QWidget):
 
         self.checkbox_gaming = QtWidgets.QCheckBox("Gaming Mode")
         self.checkbox_gaming.setToolTip(
-            "Install Steam, Lutris, Heroic, vkBasalt, MangoHud, etc."
+            "Install selected gaming packages."
         )
         self.checkbox_minimal = QtWidgets.QCheckBox("Minimal Mode")
         self.checkbox_minimal.setToolTip(
@@ -117,6 +123,28 @@ class WelcomeApp(QtWidgets.QWidget):
         self.checkbox_recommended.setToolTip("Install XanadOS full package stack.")
 
         layout.addWidget(self.checkbox_gaming)
+
+        self.gaming_group = QtWidgets.QGroupBox("Gaming Packages")
+        self.gaming_group.setVisible(False)
+        group_layout = QtWidgets.QVBoxLayout()
+        self.gaming_checks = {}
+        packages = [
+            ("steam", "Steam"),
+            ("lutris", "Lutris"),
+            ("heroic-games-launcher", "Heroic Games Launcher"),
+            ("gamemode", "GameMode"),
+            ("mangohud", "MangoHud"),
+            ("vkbasalt", "vkBasalt"),
+            ("protontricks", "Protontricks"),
+        ]
+        for pkg, label in packages:
+            cb = QtWidgets.QCheckBox(label)
+            cb.setChecked(True)
+            self.gaming_checks[pkg] = cb
+            group_layout.addWidget(cb)
+        self.gaming_group.setLayout(group_layout)
+        layout.addWidget(self.gaming_group)
+
         layout.addWidget(self.checkbox_minimal)
         layout.addWidget(self.checkbox_recommended)
 
@@ -148,6 +176,10 @@ class WelcomeApp(QtWidgets.QWidget):
             self.checkbox_recommended,
         ]:
             box.stateChanged.connect(self.update_button_state)
+
+        self.checkbox_gaming.stateChanged.connect(
+            lambda: self.gaming_group.setVisible(self.checkbox_gaming.isChecked())
+        )
 
         if os.path.exists("/etc/xanados/secureboot_enabled"):
             self.log_output.append("[!] Secure Boot is enabled.")
@@ -187,7 +219,11 @@ class WelcomeApp(QtWidgets.QWidget):
             return
         scripts = []
         if self.checkbox_gaming.isChecked():
-            scripts.append("/etc/xanados/scripts/install_gaming.sh")
+            selected = [pkg for pkg, cb in self.gaming_checks.items() if cb.isChecked()]
+            if selected:
+                scripts.append(["/etc/xanados/scripts/install_gaming.sh", *selected])
+            else:
+                scripts.append("/etc/xanados/scripts/install_gaming.sh")
         if self.checkbox_minimal.isChecked():
             scripts.append("/etc/xanados/scripts/install_minimal.sh")
         if self.checkbox_recommended.isChecked():

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -55,9 +55,6 @@ ufw-extras
 firejail
 timeshift
 snapper
-lutris
-gamemode
-retroarch
 vlc
 gwenview
 7zip
@@ -154,3 +151,20 @@ systemd-resolvconf
 tcpdump
 sbctl
 bats
+
+# Security packages
+fail2ban
+nmap
+wireshark-qt
+clamav
+rkhunter
+
+# Performance packages
+tlp
+thermald
+cpupower
+irqbalance
+preload
+earlyoom
+
+paru


### PR DESCRIPTION
## Summary
- extend ISO package list with security & performance packages
- include `paru` and remove gaming packages from base list
- update `install_gaming.sh` to accept package arguments or a file
- enhance installer UI with selectable gaming packages
- document new behavior in README

## Testing
- `python3 -m py_compile xanados-iso/airootfs/etc/xanados/welcome.py`
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`


------
https://chatgpt.com/codex/tasks/task_e_68437532b044832faa1d69a4505890ac