### PR TITLE
Add kernel selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,23 @@ If no packages are specified, a default gaming package set will be installed:
   Found in `xanados-iso/airootfs/etc/xanados/scripts/` for minimal, recommended, and gaming package installs.
 - **Calamares Integration:**  
   Custom install logic in `xanados-iso/calamares/scripts/` and modules.
-- **Mirror Selection:**  
+- **Mirror Selection:**
   Handled by `choose-mirror` script for flexible mirror configuration at boot.
+
+## Kernel Options
+
+The installer can install different kernels based on the setting in
+`/etc/xanados/package-options.conf` or the option selected in Calamares.
+Set the `KERNEL` variable to one of the following values:
+
+- `linux` – the standard Arch kernel
+- `zen` – `linux-zen` for desktop performance
+- `lts` – `linux-lts` long term support kernel
+- `hardened` – `linux-hardened` with extra security features
+- `xanmod` – `linux-xanmod` tuned for gaming
+
+During installation the **packagechooser** module installs the chosen kernel
+and removes any other kernel packages.
 
 ---
 

--- a/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
+++ b/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
@@ -5,10 +5,35 @@ echo "[INFO] Running XanadOS package chooser..."
 
 CONFIG="/etc/xanados/package-options.conf"
 if [ -f "$CONFIG" ]; then
-	# shellcheck source=/etc/xanados/package-options.conf
-	# shellcheck disable=SC1091
-	source "$CONFIG"
+    # shellcheck source=/etc/xanados/package-options.conf
+    # shellcheck disable=SC1091
+    source "$CONFIG"
 fi
 
-pacman -Syu --needed --noconfirm linux-zen
-pacman -Rns --noconfirm linux-xanmod || true
+KERNEL_CHOICE="${CALAMARES_KERNEL:-$KERNEL}"
+KERNEL_CHOICE=${KERNEL_CHOICE:-linux}
+
+# Map short names to package names
+case "$KERNEL_CHOICE" in
+    linux|base)   KERNEL_PKG="linux";;
+    zen)          KERNEL_PKG="linux-zen";;
+    lts)          KERNEL_PKG="linux-lts";;
+    hardened)     KERNEL_PKG="linux-hardened";;
+    xanmod)       KERNEL_PKG="linux-xanmod";;
+    *)
+        echo "[WARNING] Unknown kernel '$KERNEL_CHOICE', defaulting to linux"
+        KERNEL_PKG="linux"
+        ;;
+esac
+
+AVAILABLE_KERNELS=(linux linux-zen linux-lts linux-hardened linux-xanmod)
+
+# Install selected kernel
+pacman -Syu --needed --noconfirm "$KERNEL_PKG"
+
+# Remove unneeded kernels
+for k in "${AVAILABLE_KERNELS[@]}"; do
+    if [ "$k" != "$KERNEL_PKG" ]; then
+        pacman -Rns --noconfirm "$k" || true
+    fi
+done

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -1,5 +1,5 @@
 base
-linux-zen
+linux
 linux-firmware
 mkinitcpio
 btrfs-progs


### PR DESCRIPTION
## Summary
- use the base `linux` kernel for the ISO package list
- support choosing a kernel via `/etc/xanados/package-options.conf`
- document available kernel options in the README

## Testing
- `shellcheck xanados-iso/calamares/modules/packagechooser/packagechooser.sh`

------
https://chatgpt.com/codex/tasks/task_e_684379d2c1a0832fa2f3effb7d2c2ce3