### PR TITLE
Fix sbctl handling in postinstall script

### DIFF
--- a/xanados-iso/calamares/scripts/postinstall.sh
+++ b/xanados-iso/calamares/scripts/postinstall.sh
@@ -2,7 +2,8 @@
 set -e
 
 LOGFILE="/var/log/postinstall.log"
-exec > >(tee -a "$LOGFILE") 2>&1
+ERRORLOG="/var/log/postinstall-error.log"
+exec > >(tee -a "$LOGFILE") 2> >(tee -a "$LOGFILE" "$ERRORLOG" >&2)
 
 echo "[XanadOS] Starting post-install tasks..."
 
@@ -14,16 +15,18 @@ fi
 
 # Secure Boot setup placeholder
 if [ -f /etc/xanados/secureboot_enabled ]; then
-	echo "[XanadOS] Secure Boot enabled, configuring keys..."
-	if command -v sbctl >/dev/null 2>&1; then
-		sbctl create-keys
-		sbctl enroll-keys --yes-this-is-dangerous
-	else
-		echo "[ERROR] sbctl not installed, cannot enroll Secure Boot keys."
-		exit 1
-	fi
+        echo "[XanadOS] Secure Boot enabled, configuring keys..."
+        if command -v sbctl >/dev/null 2>&1; then
+                if sbctl create-keys && sbctl enroll-keys --yes-this-is-dangerous; then
+                        echo "[XanadOS] Secure Boot keys enrolled." 
+                else
+                        echo "[ERROR] sbctl failed to enroll keys, continuing installation."
+                fi
+        else
+                echo "[WARNING] sbctl not installed, skipping Secure Boot configuration."
+        fi
 else
-	echo "[XanadOS] Secure Boot not enabled."
+        echo "[XanadOS] Secure Boot not enabled."
 fi
 
 # Setup Welcome App autostart if file exists


### PR DESCRIPTION
## Summary
- warn instead of abort if sbctl is missing
- log errors to `/var/log/postinstall-error.log`
- gracefully continue install on Secure Boot key issues

## Testing
- `npx shellcheck xanados-iso/calamares/scripts/postinstall.sh`

------
https://chatgpt.com/codex/tasks/task_e_68437afe9390832fb2d1db2d8329007e