### PR TITLE
Add dry run mode for install scripts

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -4,6 +4,37 @@ set -e
 LOGFILE="/tmp/welcome_install.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 
+check_paru() {
+    if ! command -v paru >/dev/null 2>&1; then
+        echo "[ERROR] paru is not installed. Please install paru first." >&2
+        exit 1
+    fi
+}
+
+run_cmd() {
+    if $DRY_RUN; then
+        echo "DRY RUN: $*"
+    else
+        "$@"
+    fi
+}
+
+DRY_RUN=false
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
 echo "[XanadOS] Starting Gaming Stack installation at $(date)"
 
 usage() {
@@ -36,6 +67,8 @@ while getopts ":f:h" opt; do
 done
 shift $((OPTIND -1))
 
+check_paru
+
 if [[ $# -gt 0 ]]; then
     PACKAGES+=("$@")
 fi
@@ -44,7 +77,7 @@ if [[ ${#PACKAGES[@]} -eq 0 ]]; then
     PACKAGES=(steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks)
 fi
 
-if ! paru -Syu --needed --noconfirm "${PACKAGES[@]}"; then
+if ! run_cmd paru -Syu --needed --noconfirm "${PACKAGES[@]}"; then
     echo "[ERROR] Gaming Stack installation failed."
     exit 1
 fi

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
@@ -3,9 +3,39 @@ set -e
 LOGFILE="/tmp/welcome_install.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 
+check_paru() {
+    if ! command -v paru >/dev/null 2>&1; then
+        echo "[ERROR] paru is not installed. Please install paru first." >&2
+        exit 1
+    fi
+}
+
+run_cmd() {
+    if $DRY_RUN; then
+        echo "DRY RUN: $*"
+    else
+        "$@"
+    fi
+}
+
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+check_paru
+
 echo "[XanadOS] Starting Minimal environment installation at $(date)"
 
-if ! paru -Syu --needed --noconfirm plasma-desktop dolphin konsole networkmanager; then
+if ! run_cmd paru -Syu --needed --noconfirm plasma-desktop dolphin konsole networkmanager; then
 	echo "[ERROR] Minimal environment installation failed."
 	exit 1
 fi

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -3,11 +3,41 @@ set -e
 LOGFILE="/tmp/welcome_install.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 
+check_paru() {
+    if ! command -v paru >/dev/null 2>&1; then
+        echo "[ERROR] paru is not installed. Please install paru first." >&2
+        exit 1
+    fi
+}
+
+run_cmd() {
+    if $DRY_RUN; then
+        echo "DRY RUN: $*"
+    else
+        "$@"
+    fi
+}
+
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+check_paru
+
 echo "[XanadOS] Starting Full Recommended Stack installation at $(date)"
 
-if ! paru -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper; then
-	echo "[ERROR] Full Recommended Stack installation failed."
-	exit 1
+if ! run_cmd paru -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper; then
+        echo "[ERROR] Full Recommended Stack installation failed."
+        exit 1
 fi
 
 echo "[XanadOS] Note: Spotify is available from the AUR as 'spotify-launcher'."

--- a/xanados-iso/airootfs/etc/xanados/welcome.py
+++ b/xanados-iso/airootfs/etc/xanados/welcome.py
@@ -76,8 +76,9 @@ class WelcomeApp(QtWidgets.QWidget):
             self.dragPos = event.globalPos()
             event.accept()
 
-    def __init__(self):
+    def __init__(self, dry_run=False):
         super().__init__()
+        self.dry_run_default = dry_run
         self.installed = os.path.exists("/etc/xanados/installed")
         self.init_ui()
         self.thread = None
@@ -147,6 +148,13 @@ class WelcomeApp(QtWidgets.QWidget):
 
         layout.addWidget(self.checkbox_minimal)
         layout.addWidget(self.checkbox_recommended)
+
+        self.checkbox_dry_run = QtWidgets.QCheckBox("Dry Run")
+        self.checkbox_dry_run.setToolTip(
+            "Show the commands without executing them."
+        )
+        self.checkbox_dry_run.setChecked(self.dry_run_default)
+        layout.addWidget(self.checkbox_dry_run)
 
         buttons_layout = QtWidgets.QHBoxLayout()
         self.install_button = QtWidgets.QPushButton("Start Installation")
@@ -218,16 +226,17 @@ class WelcomeApp(QtWidgets.QWidget):
             )
             return
         scripts = []
+        dry_flag = ["--dry-run"] if self.checkbox_dry_run.isChecked() else []
         if self.checkbox_gaming.isChecked():
             selected = [pkg for pkg, cb in self.gaming_checks.items() if cb.isChecked()]
             if selected:
-                scripts.append(["/etc/xanados/scripts/install_gaming.sh", *selected])
+                scripts.append(["/etc/xanados/scripts/install_gaming.sh", *selected, *dry_flag])
             else:
-                scripts.append("/etc/xanados/scripts/install_gaming.sh")
+                scripts.append(["/etc/xanados/scripts/install_gaming.sh", *dry_flag])
         if self.checkbox_minimal.isChecked():
-            scripts.append("/etc/xanados/scripts/install_minimal.sh")
+            scripts.append(["/etc/xanados/scripts/install_minimal.sh", *dry_flag])
         if self.checkbox_recommended.isChecked():
-            scripts.append("/etc/xanados/scripts/install_recommended.sh")
+            scripts.append(["/etc/xanados/scripts/install_recommended.sh", *dry_flag])
 
         self.thread = InstallerThread(scripts)
         self.thread.progress.connect(
@@ -243,6 +252,7 @@ class WelcomeApp(QtWidgets.QWidget):
         self.checkbox_gaming.setEnabled(False)
         self.checkbox_minimal.setEnabled(False)
         self.checkbox_recommended.setEnabled(False)
+        self.checkbox_dry_run.setEnabled(False)
         self.thread.start()
 
     def run_maintenance(self):
@@ -289,10 +299,15 @@ class WelcomeApp(QtWidgets.QWidget):
         self.checkbox_gaming.setEnabled(True)
         self.checkbox_minimal.setEnabled(True)
         self.checkbox_recommended.setEnabled(True)
+        self.checkbox_dry_run.setEnabled(True)
 
 
 if __name__ == "__main__":
+    dry_cli = False
+    if "--dry-run" in sys.argv:
+        dry_cli = True
+        sys.argv.remove("--dry-run")
     app = QtWidgets.QApplication(sys.argv)
-    win = WelcomeApp()
+    win = WelcomeApp(dry_run=dry_cli)
     win.show()
     sys.exit(app.exec_())


### PR DESCRIPTION
## Summary
- check for `paru` before running install scripts
- allow `--dry-run` mode in install scripts
- expose dry-run toggle in `welcome.py`

## Testing
- `python3 -m py_compile xanados-iso/airootfs/etc/xanados/welcome.py`
- `bash xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68437d615124832fa68b03130c663544