### PR TITLE
Improve gaming install script package handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Or provide a file with package names:
 install_gaming.sh -f /path/to/pkglist.txt
 ```
 
+The script automatically skips packages that are already installed and prints
+the final list before running `paru`. To uninstall gaming packages, use the
+`--remove` option (optionally combine with `--dry-run` to preview changes):
+
+```bash
+install_gaming.sh --remove steam lutris
+```
+
 If no packages are specified, a default gaming package set will be installed:
 
 - steam

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -20,11 +20,16 @@ run_cmd() {
 }
 
 DRY_RUN=false
+REMOVE=false
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        --remove)
+            REMOVE=true
             shift
             ;;
         *)
@@ -38,7 +43,7 @@ set -- "${POSITIONAL[@]}"
 echo "[XanadOS] Starting Gaming Stack installation at $(date)"
 
 usage() {
-    echo "Usage: $0 [-f package_file] [packages...]" >&2
+    echo "Usage: $0 [--remove] [--dry-run] [-f package_file] [packages...]" >&2
 }
 
 PACKAGES=()
@@ -77,9 +82,41 @@ if [[ ${#PACKAGES[@]} -eq 0 ]]; then
     PACKAGES=(steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks)
 fi
 
-if ! run_cmd paru -Syu --needed --noconfirm "${PACKAGES[@]}"; then
-    echo "[ERROR] Gaming Stack installation failed."
-    exit 1
+FINAL_PKGS=()
+if $REMOVE; then
+    for pkg in "${PACKAGES[@]}"; do
+        if pacman -Qq "$pkg" >/dev/null 2>&1; then
+            FINAL_PKGS+=("$pkg")
+        else
+            echo "[INFO] Package not installed: $pkg"
+        fi
+    done
+    if [[ ${#FINAL_PKGS[@]} -eq 0 ]]; then
+        echo "[INFO] No packages to remove."
+        exit 0
+    fi
+    echo "[XanadOS] Packages to remove: ${FINAL_PKGS[*]}"
+    if ! run_cmd paru -Rns --noconfirm "${FINAL_PKGS[@]}"; then
+        echo "[ERROR] Gaming Stack removal failed."
+        exit 1
+    fi
+    echo "[XanadOS] Gaming tools removed successfully at $(date)"
+else
+    for pkg in "${PACKAGES[@]}"; do
+        if pacman -Qq "$pkg" >/dev/null 2>&1; then
+            echo "[INFO] Skipping already installed package: $pkg"
+        else
+            FINAL_PKGS+=("$pkg")
+        fi
+    done
+    if [[ ${#FINAL_PKGS[@]} -eq 0 ]]; then
+        echo "[INFO] All selected packages are already installed."
+        exit 0
+    fi
+    echo "[XanadOS] Packages to install: ${FINAL_PKGS[*]}"
+    if ! run_cmd paru -Syu --needed --noconfirm "${FINAL_PKGS[@]}"; then
+        echo "[ERROR] Gaming Stack installation failed."
+        exit 1
+    fi
+    echo "[XanadOS] Gaming tools installed successfully at $(date)"
 fi
-
-echo "[XanadOS] Gaming tools installed successfully at $(date)"


### PR DESCRIPTION
## Summary
- enhance `install_gaming.sh` to skip installed packages and display final package lists
- add `--remove` option for uninstalling gaming packages
- document new behaviour and option in README

## Testing
- `npx --yes shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`
- `npx --yes shfmt -d xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh` *(fails: could not determine executable)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68437ebc7594832fb9cf91d0fe100f88