### PR TITLE
Fix shfmt execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+/.shfmt/
 *.bak
 __pycache__/
 package.json

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Or provide a file with package names:
 install_gaming.sh -f /path/to/pkglist.txt
 ```
 
+The script automatically skips packages that are already installed and prints
+the final list before running `paru`. To uninstall gaming packages, use the
+`--remove` option (optionally combine with `--dry-run` to preview changes):
+
+```bash
+install_gaming.sh --remove steam lutris
+```
+
 If no packages are specified, a default gaming package set will be installed:
 
 - steam
@@ -139,6 +147,17 @@ and removes any other kernel packages.
 ![Welcome App](screenshots/welcome.png)
 ![Gaming Stack Selection](screenshots/gaming.png)
 -->
+
+## Development
+
+Formatting scripts requires the `shfmt` tool. This repository includes
+`bin/shfmt.js`, which downloads a prebuilt binary on first run.
+
+```bash
+node bin/shfmt.js -d path/to/script.sh
+```
+
+This avoids the broken `shfmt` npm package.
 
 ---
 

--- a/bin/shfmt.js
+++ b/bin/shfmt.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const {execFileSync, spawnSync} = require('child_process');
+const os = require('os');
+const path = require('path');
+
+const VERSION = 'v3.7.0';
+const BIN_DIR = path.join(__dirname, '..', '.shfmt');
+const BIN_PATH = path.join(BIN_DIR, 'shfmt');
+
+function download(url, dest) {
+  const res = spawnSync('curl', ['-L', '-o', dest, url]);
+  if (res.status !== 0) {
+    throw new Error('Failed to download shfmt');
+  }
+  fs.chmodSync(dest, 0o755);
+}
+
+async function ensureBinary() {
+  if (fs.existsSync(BIN_PATH)) return;
+  fs.mkdirSync(BIN_DIR, {recursive: true});
+  const platform = os.platform();
+  const arch = os.arch();
+  let url;
+  if (platform === 'linux' && arch === 'x64') {
+    url = `https://github.com/mvdan/sh/releases/download/${VERSION}/shfmt_${VERSION}_linux_amd64`;
+  } else if (platform === 'linux' && arch === 'arm64') {
+    url = `https://github.com/mvdan/sh/releases/download/${VERSION}/shfmt_${VERSION}_linux_arm64`;
+  } else if (platform === 'darwin' && arch === 'x64') {
+    url = `https://github.com/mvdan/sh/releases/download/${VERSION}/shfmt_${VERSION}_darwin_amd64`;
+  } else if (platform === 'darwin' && arch === 'arm64') {
+    url = `https://github.com/mvdan/sh/releases/download/${VERSION}/shfmt_${VERSION}_darwin_arm64`;
+  } else if (platform === 'win32' && arch === 'x64') {
+    url = `https://github.com/mvdan/sh/releases/download/${VERSION}/shfmt_${VERSION}_windows_amd64.exe`;
+  } else {
+    throw new Error(`Unsupported platform: ${platform}-${arch}`);
+  }
+  await download(url, BIN_PATH);
+}
+
+(async () => {
+  try {
+    await ensureBinary();
+    const args = process.argv.slice(2);
+    execFileSync(BIN_PATH, args, {stdio: 'inherit'});
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+})();

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -5,81 +5,118 @@ LOGFILE="/tmp/welcome_install.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 
 check_paru() {
-    if ! command -v paru >/dev/null 2>&1; then
-        echo "[ERROR] paru is not installed. Please install paru first." >&2
-        exit 1
-    fi
+	if ! command -v paru >/dev/null 2>&1; then
+		echo "[ERROR] paru is not installed. Please install paru first." >&2
+		exit 1
+	fi
 }
 
 run_cmd() {
-    if $DRY_RUN; then
-        echo "DRY RUN: $*"
-    else
-        "$@"
-    fi
+	if $DRY_RUN; then
+		echo "DRY RUN: $*"
+	else
+		"$@"
+	fi
 }
 
 DRY_RUN=false
+REMOVE=false
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        --dry-run)
-            DRY_RUN=true
-            shift
-            ;;
-        *)
-            POSITIONAL+=("$1")
-            shift
-            ;;
-    esac
+	case $1 in
+	--dry-run)
+		DRY_RUN=true
+		shift
+		;;
+	--remove)
+		REMOVE=true
+		shift
+		;;
+	*)
+		POSITIONAL+=("$1")
+		shift
+		;;
+	esac
 done
 set -- "${POSITIONAL[@]}"
 
 echo "[XanadOS] Starting Gaming Stack installation at $(date)"
 
 usage() {
-    echo "Usage: $0 [-f package_file] [packages...]" >&2
+	echo "Usage: $0 [--remove] [--dry-run] [-f package_file] [packages...]" >&2
 }
 
 PACKAGES=()
 while getopts ":f:h" opt; do
-    case $opt in
-        f)
-            if [[ -f $OPTARG ]]; then
-                while IFS= read -r line; do
-                    [[ -z $line || $line =~ ^# ]] && continue
-                    PACKAGES+=("$line")
-                done < "$OPTARG"
-            else
-                echo "[ERROR] Package file not found: $OPTARG" >&2
-                exit 1
-            fi
-            ;;
-        h)
-            usage
-            exit 0
-            ;;
-        ?)
-            usage
-            exit 1
-            ;;
-    esac
+	case $opt in
+	f)
+		if [[ -f $OPTARG ]]; then
+			while IFS= read -r line; do
+				[[ -z $line || $line =~ ^# ]] && continue
+				PACKAGES+=("$line")
+			done <"$OPTARG"
+		else
+			echo "[ERROR] Package file not found: $OPTARG" >&2
+			exit 1
+		fi
+		;;
+	h)
+		usage
+		exit 0
+		;;
+	?)
+		usage
+		exit 1
+		;;
+	esac
 done
-shift $((OPTIND -1))
+shift $((OPTIND - 1))
 
 check_paru
 
 if [[ $# -gt 0 ]]; then
-    PACKAGES+=("$@")
+	PACKAGES+=("$@")
 fi
 
 if [[ ${#PACKAGES[@]} -eq 0 ]]; then
-    PACKAGES=(steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks)
+	PACKAGES=(steam lutris heroic-games-launcher gamemode mangohud vkbasalt protontricks)
 fi
 
-if ! run_cmd paru -Syu --needed --noconfirm "${PACKAGES[@]}"; then
-    echo "[ERROR] Gaming Stack installation failed."
-    exit 1
+FINAL_PKGS=()
+if $REMOVE; then
+	for pkg in "${PACKAGES[@]}"; do
+		if pacman -Qq "$pkg" >/dev/null 2>&1; then
+			FINAL_PKGS+=("$pkg")
+		else
+			echo "[INFO] Package not installed: $pkg"
+		fi
+	done
+	if [[ ${#FINAL_PKGS[@]} -eq 0 ]]; then
+		echo "[INFO] No packages to remove."
+		exit 0
+	fi
+	echo "[XanadOS] Packages to remove: ${FINAL_PKGS[*]}"
+	if ! run_cmd paru -Rns --noconfirm "${FINAL_PKGS[@]}"; then
+		echo "[ERROR] Gaming Stack removal failed."
+		exit 1
+	fi
+	echo "[XanadOS] Gaming tools removed successfully at $(date)"
+else
+	for pkg in "${PACKAGES[@]}"; do
+		if pacman -Qq "$pkg" >/dev/null 2>&1; then
+			echo "[INFO] Skipping already installed package: $pkg"
+		else
+			FINAL_PKGS+=("$pkg")
+		fi
+	done
+	if [[ ${#FINAL_PKGS[@]} -eq 0 ]]; then
+		echo "[INFO] All selected packages are already installed."
+		exit 0
+	fi
+	echo "[XanadOS] Packages to install: ${FINAL_PKGS[*]}"
+	if ! run_cmd paru -Syu --needed --noconfirm "${FINAL_PKGS[@]}"; then
+		echo "[ERROR] Gaming Stack installation failed."
+		exit 1
+	fi
+	echo "[XanadOS] Gaming tools installed successfully at $(date)"
 fi
-
-echo "[XanadOS] Gaming tools installed successfully at $(date)"


### PR DESCRIPTION
## Summary
- add `bin/shfmt.js` wrapper for downloading and running shfmt
- ignore the `.shfmt` directory
- document how to use the wrapper in the README
- add package skipping and `--remove` option to `install_gaming.sh`
- show final package list before running paru
- format `install_gaming.sh`

## Testing
- `npx --yes shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`
- `node bin/shfmt.js -d xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68437ebc7594832fb9cf91d0fe100f88