### PR TITLE
Add timestamped logs and log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If no packages are specified, a default gaming package set will be installed:
 - vkbasalt
 - protontricks
 
-> **Tip:** All installer scripts (minimal, recommended, gaming) log to `/tmp/welcome_install.log` for troubleshooting.
+> **Tip:** Each installer script writes to its own timestamped log in `/tmp` such as `/tmp/welcome_install_YYYYMMDD_HHMMSS.log`. The Welcome app will show the most recent log automatically.
 
 ---
 

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-LOGFILE="/tmp/welcome_install.log"
+LOGFILE="/tmp/welcome_install_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOGFILE") 2>&1
+echo "[INFO] Log file: $LOGFILE"
 
 check_paru() {
     if ! command -v paru >/dev/null 2>&1; then

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
-LOGFILE="/tmp/welcome_install.log"
+LOGFILE="/tmp/welcome_install_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOGFILE") 2>&1
+echo "[INFO] Log file: $LOGFILE"
 
 check_paru() {
     if ! command -v paru >/dev/null 2>&1; then

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
-LOGFILE="/tmp/welcome_install.log"
+LOGFILE="/tmp/welcome_install_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOGFILE") 2>&1
+echo "[INFO] Log file: $LOGFILE"
 
 check_paru() {
     if ! command -v paru >/dev/null 2>&1; then

--- a/xanados-iso/airootfs/etc/xanados/welcome.py
+++ b/xanados-iso/airootfs/etc/xanados/welcome.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import subprocess
+import glob
 from datetime import datetime
 from PyQt5 import QtWidgets, QtGui, QtCore
 
@@ -10,6 +11,7 @@ from PyQt5 import QtWidgets, QtGui, QtCore
 class InstallerThread(QtCore.QThread):
     progress = QtCore.pyqtSignal(str)
     finished = QtCore.pyqtSignal(bool)
+    log_path = QtCore.pyqtSignal(str)
 
     def __init__(self, scripts):
         super().__init__()
@@ -47,8 +49,11 @@ class InstallerThread(QtCore.QThread):
                         self.progress.emit("[INFO] Installation cancelled by user.")
                         success = False
                         break
+                    line = line.strip()
                     timestamp = datetime.now().strftime("%H:%M:%S")
-                    self.progress.emit(f"[{timestamp}] {line.strip()}")
+                    self.progress.emit(f"[{timestamp}] {line}")
+                    if "Log file:" in line:
+                        self.log_path.emit(line.split("Log file:", 1)[1].strip())
                 process.wait()
                 if process.returncode != 0:
                     self.progress.emit(f"[ERROR] Script failed: {script}")
@@ -176,6 +181,14 @@ class WelcomeApp(QtWidgets.QWidget):
         self.log_output.setReadOnly(True)
         layout.addWidget(self.log_output)
 
+        self.log_label = QtWidgets.QLabel("")
+        layout.addWidget(self.log_label)
+
+        self.log_file = None
+        self.log_timer = QtCore.QTimer(self)
+        self.log_timer.timeout.connect(self.read_log_updates)
+        self.find_latest_log()
+
         self.setLayout(layout)
 
         for box in [
@@ -245,6 +258,7 @@ class WelcomeApp(QtWidgets.QWidget):
                 self.log_output.ensureCursorVisible(),
             )
         )
+        self.thread.log_path.connect(self.set_log_file)
         self.thread.finished.connect(self.install_finished)
         self.progress_bar.setVisible(True)
         self.install_button.setEnabled(False)
@@ -300,6 +314,38 @@ class WelcomeApp(QtWidgets.QWidget):
         self.checkbox_minimal.setEnabled(True)
         self.checkbox_recommended.setEnabled(True)
         self.checkbox_dry_run.setEnabled(True)
+
+    def find_latest_log(self):
+        logs = glob.glob("/tmp/welcome_install_*.log")
+        if logs:
+            latest = max(logs, key=os.path.getmtime)
+            self.set_log_file(latest)
+        else:
+            self.log_label.setText("Log file: none found")
+
+    def set_log_file(self, path):
+        if getattr(self, "log_file", None):
+            try:
+                self.log_file.close()
+            except Exception:
+                pass
+        self.log_file_path = path
+        try:
+            self.log_file = open(path, "r")
+            self.log_label.setText(f"Log file: {path}")
+        except Exception as e:
+            self.log_output.append(f"[ERROR] Unable to open log {path}: {e}")
+            self.log_label.setText(f"Log file: {path} (error)")
+            self.log_file = None
+            return
+        self.log_timer.start(1000)
+
+    def read_log_updates(self):
+        if not getattr(self, "log_file", None):
+            return
+        for line in self.log_file.readlines():
+            self.log_output.append(line.rstrip())
+            self.log_output.ensureCursorVisible()
 
 
 if __name__ == "__main__":

--- a/xanados-iso/airootfs/usr/local/bin/choose-mirror
+++ b/xanados-iso/airootfs/usr/local/bin/choose-mirror
@@ -18,6 +18,14 @@ mirror="$(get_cmdline mirror)"
 [[ "$mirror" == 'auto' ]] && mirror="$(get_cmdline archiso_http_srv)"
 
 log_file="/var/log/choose-mirror.log"
+rotate_logs() {
+    local f="$1" max=5
+    for ((i=max; i>=1; i--)); do
+        [ -f "${f}.${i}" ] && mv "${f}.${i}" "${f}.$((i+1))"
+    done
+    [ -f "$f" ] && mv "$f" "$f.1"
+}
+rotate_logs "$log_file"
 
 if [[ -z "$mirror" ]]; then
     if [[ -f /etc/pacman.d/mirrorlist.default ]]; then

--- a/xanados-iso/calamares/scripts/postinstall.sh
+++ b/xanados-iso/calamares/scripts/postinstall.sh
@@ -3,6 +3,15 @@ set -e
 
 LOGFILE="/var/log/postinstall.log"
 ERRORLOG="/var/log/postinstall-error.log"
+rotate_logs() {
+    local f="$1" max=5
+    for ((i=max; i>=1; i--)); do
+        [ -f "${f}.${i}" ] && mv "${f}.${i}" "${f}.$((i+1))"
+    done
+    [ -f "$f" ] && mv "$f" "$f.1"
+}
+rotate_logs "$LOGFILE"
+rotate_logs "$ERRORLOG"
 exec > >(tee -a "$LOGFILE") 2> >(tee -a "$LOGFILE" "$ERRORLOG" >&2)
 
 echo "[XanadOS] Starting post-install tasks..."

--- a/xanados-iso/calamares/scripts/systemd-service-cleanup.sh
+++ b/xanados-iso/calamares/scripts/systemd-service-cleanup.sh
@@ -2,6 +2,14 @@
 set -e
 
 LOGFILE="/var/log/systemd-service-cleanup.log"
+rotate_logs() {
+    local f="$1" max=5
+    for ((i=max; i>=1; i--)); do
+        [ -f "${f}.${i}" ] && mv "${f}.${i}" "${f}.$((i+1))"
+    done
+    [ -f "$f" ] && mv "$f" "$f.1"
+}
+rotate_logs "$LOGFILE"
 exec > >(tee -a "$LOGFILE") 2>&1
 
 echo "[XanadOS] Starting systemd service cleanup at $(date)"


### PR DESCRIPTION
## Summary
- generate timestamped log filenames for installer scripts
- rotate logs for persistent postinstall scripts
- track latest installer log in Welcome app
- update documentation about the new logging behaviour

## Testing
- `python3 -m py_compile xanados-iso/airootfs/etc/xanados/welcome.py`

------
https://chatgpt.com/codex/tasks/task_e_6843855b3290832f89910f349967e3bb