### PR TITLE
Enhance script robustness and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y shellcheck bats
+      - name: Install Node dependencies
+        run: npm ci
+      - name: Verify required files
+        run: |
+          test -f xanados-iso/airootfs/etc/xanados/scripts/common.sh
+          test -f xanados-iso/calamares/scripts/postinstall.sh
       - name: Lint shell scripts
-        run: shellcheck xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh build.sh
+        run: shellcheck -x xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh build.sh
       - name: Run tests
         run: bats tests

--- a/README.md
+++ b/README.md
@@ -60,12 +60,16 @@ cd xanados/xanados-iso
 > - `archiso` and other build dependencies installed
 
 ```bash
-# Replace with your actual build command or script
-# Example using archiso:
+# Option A: use mkarchiso directly
 sudo mkarchiso -v .
-# or if you use a custom script:
+
+# Option B: use the helper script which sets up work/output dirs
 ./build.sh
 ```
+
+The `build.sh` script wraps `mkarchiso` and automatically creates `work/` and
+`out/` directories. Set `WORK_DIR` or `OUT_DIR` environment variables to
+override their locations if needed.
 
 The generated ISO will appear in the `out/` directory by default.
 
@@ -154,7 +158,9 @@ XanadOS supports Secure Boot via the `secureboot-toggle` Calamares module. Packa
 -->
 
 ## Testing
-Run `bats tests` to execute the basic shell unit tests. Shell scripts are linted with `shellcheck` and both run automatically in CI.
+Run `shellcheck -x xanados-iso/airootfs/etc/xanados/scripts/*.sh \
+  xanados-iso/calamares/scripts/*.sh build.sh` locally before committing.
+Unit tests run with `bats tests`. Both checks also execute automatically in CI.
 ---
 
 ## Community & Support

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=common.sh disable=SC1091
 source "$(dirname "$0")/common.sh"
 init_logging install_gaming
 
 DRY_RUN=false
+export DRY_RUN
 REMOVE=false
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=common.sh disable=SC1091
 source "$(dirname "$0")/common.sh"
 init_logging install_minimal
 
 DRY_RUN=false
+export DRY_RUN
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=common.sh disable=SC1091
 source "$(dirname "$0")/common.sh"
 init_logging install_recommended
 
 DRY_RUN=false
+export DRY_RUN
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)

--- a/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
+++ b/xanados-iso/calamares/modules/packagechooser/packagechooser.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "[INFO] Running XanadOS package chooser..."
 

--- a/xanados-iso/calamares/modules/secureboot-toggle/secureboot.sh
+++ b/xanados-iso/calamares/modules/secureboot-toggle/secureboot.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "[INFO] Applying Secure Boot toggle..."
 


### PR DESCRIPTION
## Summary
- improve mkarchiso build docs
- document running shellcheck locally
- harden installer scripts and set DRY_RUN as exported var
- make calamares scripts more strict
- install Node and cache modules in CI
- verify required files before running checks

## Testing
- `shellcheck -x xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh build.sh`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6844735add70832fa3b22dd9a6e459aa