### PR TITLE
Fix shellcheck missing file

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=xanados-iso/airootfs/etc/xanados/scripts/common.sh
 source "$(dirname "$0")/common.sh"
 init_logging install_gaming
 

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_minimal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=xanados-iso/airootfs/etc/xanados/scripts/common.sh
 source "$(dirname "$0")/common.sh"
 init_logging install_minimal
 

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=xanados-iso/airootfs/etc/xanados/scripts/common.sh
 source "$(dirname "$0")/common.sh"
 init_logging install_recommended
 


### PR DESCRIPTION
## Summary
- ensure shellcheck can locate common.sh

## Testing
- `npx shellcheck -x xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh build.sh`
- `npx bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68448a3ec938832fa2d7db9b2fb8ed40