### PR TITLE
Fix run_cmd return status

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/common.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/common.sh
@@ -26,7 +26,9 @@ check_paru() {
 run_cmd() {
     if [[ "${DRY_RUN:-false}" == true ]]; then
         echo "DRY RUN: $*"
+        return 0  # Explicitly return success status for dry-run
     else
         "$@"
+        return $?  # Return the status of the executed command
     fi
 }


### PR DESCRIPTION
## Summary
- ensure `run_cmd` returns success in DRY_RUN mode and propagates command exit code

## Testing
- `npx bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6845a8479754832fb97da0d754580b45