### PR TITLE
Refactor logging initialization

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/common.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/common.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_DIR="/var/log/xanados"
-mkdir -p "$LOG_DIR"
+# Allow overriding the log directory via the LOG_DIR environment variable
+LOG_DIR="${LOG_DIR:-/var/log/xanados}"
 
 init_logging() {
     local prefix=${1:-script}
+
+    # Attempt to create the preferred log directory. If that fails, fall back to
+    # /tmp/xanados so logging still works even on read-only filesystems.
+    if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+        echo "[WARN] Could not create log directory $LOG_DIR. Falling back to /tmp/xanados" >&2
+        LOG_DIR=/tmp/xanados
+        mkdir -p "$LOG_DIR" || {
+            echo "[ERROR] Failed to create fallback log directory $LOG_DIR" >&2
+            return 1
+        }
+    fi
+
     LOGFILE="$LOG_DIR/${prefix}_$(date +%Y%m%d_%H%M%S).log"
     exec > >(tee -a "$LOGFILE") 2>&1
     echo "[INFO] Log file: $LOGFILE"


### PR DESCRIPTION
## Summary
- allow overriding `LOG_DIR` and handle directory creation inside `init_logging`
- add fallback to `/tmp/xanados` when log dir creation fails

## Testing
- `npx bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6845ab19ab1c832faae9d50347882015