### PR TITLE
Fix common.sh logging and update Bats tests

### DIFF
--- a/tests/common.bats
+++ b/tests/common.bats
@@ -1,11 +1,13 @@
 #!/usr/bin/env bats
 
 @test "run_cmd executes" {
-  run bash -c 'DRY_RUN=false; source xanados-iso/airootfs/etc/xanados/scripts/common.sh; run_cmd true'
+  run bash -c 'LOG_DIR=/tmp/xanados-test; DRY_RUN=false; source xanados-iso/airootfs/etc/xanados/scripts/common.sh; run_cmd echo hi'
   [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "hi" ]
 }
 
 @test "run_cmd dry-run" {
-  run bash -c 'DRY_RUN=true; source xanados-iso/airootfs/etc/xanados/scripts/common.sh; run_cmd echo hi'
+  run bash -c 'LOG_DIR=/tmp/xanados-test; DRY_RUN=true; source xanados-iso/airootfs/etc/xanados/scripts/common.sh; run_cmd echo hi'
   [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "DRY RUN: echo hi" ]
 }

--- a/xanados-iso/airootfs/etc/xanados/scripts/common.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/common.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG_DIR="/var/log/xanados"
-mkdir -p "$LOG_DIR"
+LOG_DIR="${LOG_DIR:-/var/log/xanados}"
 
 init_logging() {
     local prefix=${1:-script}
+    mkdir -p "$LOG_DIR"
     LOGFILE="$LOG_DIR/${prefix}_$(date +%Y%m%d_%H%M%S).log"
     exec > >(tee -a "$LOGFILE") 2>&1
     echo "[INFO] Log file: $LOGFILE"


### PR DESCRIPTION
## Summary
- allow tests to override `LOG_DIR` before sourcing scripts
- create log directory inside `init_logging`
- ensure unit tests check command output in normal and dry-run modes

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/common.sh`
- `shellcheck tests/common.bats`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6845ab1d7f3c832f91bfb7bbfd0643ef