### PR TITLE
Fix run_cmd return behavior

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/common.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/common.sh
@@ -40,7 +40,8 @@ check_paru() {
 run_cmd() {
     if [[ "${DRY_RUN:-false}" == true ]]; then
         echo "DRY RUN: $*"
-    else
-        "$@"
+        return 0
     fi
+    "$@"
+    return $?
 }


### PR DESCRIPTION
## Summary
- update `run_cmd` to explicitly return 0 in dry run mode and the command status otherwise

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/common.sh`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6845ae63e988832fa785ec40fcb06f36