### PR TITLE
Add shellcheck coverage for more scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y shellcheck bats
       - name: Lint shell scripts
-        run: shellcheck xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh build.sh
+        run: |
+          shellcheck \
+            xanados-iso/airootfs/etc/xanados/scripts/*.sh \
+            xanados-iso/calamares/scripts/*.sh \
+            xanados-iso/calamares/modules/**/*.sh \
+            xanados-iso/airootfs/usr/local/bin/*.sh \
+            build.sh
       - name: Run tests
         run: bats tests


### PR DESCRIPTION
## Summary
- update CI to check additional shell scripts

## Testing
- `bats tests`
- `bash -c 'shopt -s nullglob; if shellcheck xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh xanados-iso/calamares/modules/**/*.sh xanados-iso/airootfs/usr/local/bin/*.sh build.sh; then echo OK; else echo FAIL; fi'`


------
https://chatgpt.com/codex/tasks/task_e_6845b156e534832f9bd6d63a77b92a81