### PR TITLE
Replace 7zip with p7zip in packages list

### DIFF
--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -57,7 +57,7 @@ timeshift
 snapper
 vlc
 gwenview
-7zip
+p7zip
 file-roller
 base-devel
 cmake


### PR DESCRIPTION
## Summary
- use official `p7zip` instead of `7zip`

## Testing
- `npx shellcheck xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/profiledef.sh xanados-iso/calamares/modules/packagechooser/packagechooser.sh xanados-iso/calamares/modules/secureboot-toggle/secureboot.sh xanados-iso/calamares/scripts/*.sh`
- `npx bats tests`


------
https://chatgpt.com/codex/tasks/task_e_6845b2be1820832fb23e197ae06cf819