### PR TITLE
Update ISO package list

### DIFF
--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -3,6 +3,7 @@ linux
 linux-firmware
 mkinitcpio
 btrfs-progs
+btrfs-assistant
 efibootmgr
 grub
 plymouth
@@ -44,6 +45,7 @@ breeze-icons
 firefox
 plasma-nm
 flatpak
+flatpak-builder
 gnome-keyring
 torbrowser-launcher
 alacritty
@@ -69,6 +71,8 @@ fuse3
 gvfs
 gvfs-smb
 gvfs-nfs
+qemu
+libvirt
 qemu-guest-agent
 virt-manager
 memtest86+-efi


### PR DESCRIPTION
## Summary
- include btrfs-assistant for better filesystem management
- include flatpak-builder for building Flatpaks
- add qemu and libvirt for virtualization

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh xanados-iso/calamares/modules/**/*.sh build.sh` *(fails: `xanados-iso/airootfs/usr/local/bin/*.sh` not found)*
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6845b67b654c832fb9cf4c5722bf3fcd