### PR TITLE
Add browser options to ISO installer

### DIFF
--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -4,22 +4,32 @@ source "$(dirname "$0")/common.sh"
 init_logging install_recommended
 
 DRY_RUN=false
+BROWSER="brave"
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --dry-run)
-            DRY_RUN=true
-            shift
-            ;;
-        *)
-            break
-            ;;
+    --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+    --browser)
+        if [[ -n ${2:-} ]]; then
+            BROWSER="$2"
+            shift 2
+        else
+            echo "[ERROR] --browser requires an argument" >&2
+            exit 1
+        fi
+        ;;
+    *)
+        break
+        ;;
     esac
 done
 
 check_paru
 
 echo "[XanadOS] Starting Full Recommended Stack installation at $(date)"
-if ! run_cmd paru -Syu --needed --noconfirm flatpak firefox vlc gwenview btop timeshift snapper; then
+if ! run_cmd paru -Syu --needed --noconfirm flatpak "$BROWSER" vlc gwenview btop timeshift snapper; then
     echo "[ERROR] Full Recommended Stack installation failed."
     exit 1
 fi
@@ -28,4 +38,3 @@ echo "[XanadOS] Note: Spotify is available from the AUR as 'spotify-launcher'."
 echo "Install it manually after setting up an AUR helper."
 
 echo "[XanadOS] Full package set installed successfully at $(date)"
-

--- a/xanados-iso/airootfs/etc/xanados/welcome.py
+++ b/xanados-iso/airootfs/etc/xanados/welcome.py
@@ -118,9 +118,7 @@ class WelcomeApp(QtWidgets.QWidget):
         layout.addLayout(top_bar)
 
         self.checkbox_gaming = QtWidgets.QCheckBox("Gaming Mode")
-        self.checkbox_gaming.setToolTip(
-            "Install selected gaming packages."
-        )
+        self.checkbox_gaming.setToolTip("Install selected gaming packages.")
         self.checkbox_minimal = QtWidgets.QCheckBox("Minimal Mode")
         self.checkbox_minimal.setToolTip(
             "Install only the essential packages for a clean setup."
@@ -154,10 +152,25 @@ class WelcomeApp(QtWidgets.QWidget):
         layout.addWidget(self.checkbox_minimal)
         layout.addWidget(self.checkbox_recommended)
 
+        self.browser_options = {
+            "Brave": "brave",
+            "Firefox": "firefox",
+            "Chromium": "chromium",
+            "Vivaldi": "vivaldi",
+            "Tor Browser": "torbrowser-launcher",
+            "Opera": "opera",
+        }
+        browser_layout = QtWidgets.QHBoxLayout()
+        browser_label = QtWidgets.QLabel("Web Browser:")
+        self.browser_combo = QtWidgets.QComboBox()
+        self.browser_combo.addItems(self.browser_options.keys())
+        self.browser_combo.setCurrentText("Brave")
+        browser_layout.addWidget(browser_label)
+        browser_layout.addWidget(self.browser_combo)
+        layout.addLayout(browser_layout)
+
         self.checkbox_dry_run = QtWidgets.QCheckBox("Dry Run")
-        self.checkbox_dry_run.setToolTip(
-            "Show the commands without executing them."
-        )
+        self.checkbox_dry_run.setToolTip("Show the commands without executing them.")
         self.checkbox_dry_run.setChecked(self.dry_run_default)
         layout.addWidget(self.checkbox_dry_run)
 
@@ -243,13 +256,23 @@ class WelcomeApp(QtWidgets.QWidget):
         if self.checkbox_gaming.isChecked():
             selected = [pkg for pkg, cb in self.gaming_checks.items() if cb.isChecked()]
             if selected:
-                scripts.append(["/etc/xanados/scripts/install_gaming.sh", *selected, *dry_flag])
+                scripts.append(
+                    ["/etc/xanados/scripts/install_gaming.sh", *selected, *dry_flag]
+                )
             else:
                 scripts.append(["/etc/xanados/scripts/install_gaming.sh", *dry_flag])
         if self.checkbox_minimal.isChecked():
             scripts.append(["/etc/xanados/scripts/install_minimal.sh", *dry_flag])
         if self.checkbox_recommended.isChecked():
-            scripts.append(["/etc/xanados/scripts/install_recommended.sh", *dry_flag])
+            browser_pkg = self.browser_options[self.browser_combo.currentText()]
+            scripts.append(
+                [
+                    "/etc/xanados/scripts/install_recommended.sh",
+                    "--browser",
+                    browser_pkg,
+                    *dry_flag,
+                ]
+            )
 
         self.thread = InstallerThread(scripts)
         self.thread.progress.connect(

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -42,12 +42,17 @@ plasma-pa
 breeze
 breeze-gtk
 breeze-icons
+# Browsers
+brave
 firefox
+chromium
+vivaldi
+opera
+torbrowser-launcher
 plasma-nm
 flatpak
 flatpak-builder
 gnome-keyring
-torbrowser-launcher
 alacritty
 btop
 conky


### PR DESCRIPTION
## Summary
- include multiple browsers in package list
- allow choosing browser during installation
- default to Brave browser for the recommended install stack

## Testing
- `black xanados-iso/airootfs/etc/xanados/welcome.py --check`
- `pylint xanados-iso/airootfs/etc/xanados/welcome.py`
- `shellcheck -e SC1091 -e SC2034 xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh`
- `bats var/tests/common.bats`

------
https://chatgpt.com/codex/tasks/task_e_6845d40d6c90832fac7dbd92c0260ccc