### PR TITLE
Add missing ISO build script

### DIFF
--- a/xanados-iso/build.sh
+++ b/xanados-iso/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORK_DIR=${WORK_DIR:-work}
+OUT_DIR=${OUT_DIR:-out}
+PROFILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$WORK_DIR" "$OUT_DIR"
+
+echo "[XanadOS] Building ISO from profile $PROFILE_DIR..."
+mkarchiso -v -w "$WORK_DIR" -o "$OUT_DIR" "$PROFILE_DIR"
+
+echo "[XanadOS] Build complete. ISO is in $OUT_DIR"


### PR DESCRIPTION
## Summary
- add `xanados-iso/build.sh` to build ISO from profile

## Testing
- `shellcheck xanados-iso/build.sh`
- `bats var/tests`

------
https://chatgpt.com/codex/tasks/task_e_6845d825c94c832fa3e44bc40cc43959