### PR TITLE
Add gaming packages directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This approach allows Codex to efficiently organize and delegate work, using agen
 | xanados-iso/profiledef.sh                       | Codex-Core         | Kernel and ISO settings  |
 | xanados-iso/build.sh                            | Codex-Core         | ISO build script         |
 | xanados-iso/airootfs/usr/bin/install_gaming.sh  | Codex-Gaming       | Game layer scripting     |
+| xanados-iso/airootfs/usr/bin/packages/gaming/   | Codex-Gaming       | Package lists for games  |
 | xanados-iso/calamares/                          | Codex-Calamares    | Installer logic          |
 | xanados-iso/airootfs/etc/clamav.conf            | Codex-Security     | Security config          |
 | .github/                                        | Codex-LintOps      | CI config and workflows  |
@@ -752,5 +753,6 @@ A: Follow the steps in [Conflict Avoidance Policy](#conflict-avoidance-policy) a
 | 2025-06-08 | 2.0     | asafelobotomy  | Major rewrite: expanded agent details, navigation, logging, FAQ, quick reference, lifecycle, and contribution guidelines |
 | 2025-06-08 | 2.1     | asafelobotomy  | Added "Suggested Commands" section for recommended environment-appropriate commands |
 | 2025-06-08 | 2.2     | asafelobotomy  | Improved formatting, added troubleshooting tips, expanded FAQ, checklist templates, and visual flowcharts |
+| 2025-06-08 | 2.3     | codex          | Added `install_gaming.sh` to `/usr/bin` and gaming package lists directory |
 
 [⬆️ Back to Top](#agents-refined)

--- a/xanados-iso/airootfs/usr/bin/install_gaming.sh
+++ b/xanados-iso/airootfs/usr/bin/install_gaming.sh
@@ -1,0 +1,1 @@
+../../etc/xanados/scripts/install_gaming.sh

--- a/xanados-iso/airootfs/usr/bin/packages/gaming/README.md
+++ b/xanados-iso/airootfs/usr/bin/packages/gaming/README.md
@@ -1,0 +1,3 @@
+# Gaming Packages
+
+This directory holds example package lists for the `install_gaming.sh` script. Use these lists to install or remove groups of gaming tools.

--- a/xanados-iso/airootfs/usr/bin/packages/gaming/default.txt
+++ b/xanados-iso/airootfs/usr/bin/packages/gaming/default.txt
@@ -1,0 +1,4 @@
+# Default gaming packages
+steam
+lutris
+heroic-games-launcher


### PR DESCRIPTION
## Summary
- symlink `install_gaming.sh` into `/usr/bin`
- add `/usr/bin/packages/gaming/` with example list
- document new directory and script in AGENTS

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`
- `shfmt -d xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845e5decf68832f85d32c15e466360c