### PR TITLE
fix(ci): run bats from var/tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
             xanados-iso/airootfs/usr/local/bin/*.sh \
             build.sh
       - name: Run tests
-        run: bats tests
+        run: bats var/tests

--- a/var/logs/codex/Codex-LintOps_20250608_201119.json
+++ b/var/logs/codex/Codex-LintOps_20250608_201119.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": "2025-06-08T20:11:19Z",
+  "task_description": "Update CI workflow to run bats from var/tests",
+  "files_modified": [".github/workflows/ci.yml"],
+  "validation_results": "bats tests passed",
+  "outcome": "SUCCESS"
+}

--- a/var/logs/codex/Codex-LintOps_20250608_201119.log.txt
+++ b/var/logs/codex/Codex-LintOps_20250608_201119.log.txt
@@ -1,0 +1,1 @@
+[2025-06-08 20:11:19Z] Codex-LintOps: Updated CI workflow to use var/tests. Validation: bats tests passed. Outcome: SUCCESS.


### PR DESCRIPTION
## Summary
- point CI bats tests at var/tests instead of top-level tests
- log CI workflow change in var/logs/codex

## Testing
- `bats var/tests`
- `shellcheck build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845edebc9ac832fafc72676f58223f6