### PR TITLE
docs: update test command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ XanadOS supports Secure Boot via the `secureboot-toggle` Calamares module. Packa
 -->
 
 ## Testing
-Run `bats tests` to execute the basic shell unit tests. Shell scripts are linted with `shellcheck` and both run automatically in CI.
+Run `bats var/tests` to execute the basic shell unit tests. Shell scripts are linted with `shellcheck` and both run automatically in CI.
 ---
 
 ## Community & Support


### PR DESCRIPTION
## Summary
- fix README testing instructions to refer to `var/tests`

## Testing
- `markdownlint README.md` *(fails: line length, blanks around lists, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845edf10f20832f983c10ac2cd2b9b9