### PR TITLE
Remove root build script and update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
             xanados-iso/calamares/scripts/*.sh \
             xanados-iso/calamares/modules/**/*.sh \
             xanados-iso/airootfs/usr/local/bin/*.sh \
-            build.sh
+            xanados-iso/build.sh
       - name: Run tests
         run: bats tests

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cd xanados/xanados-iso
 # Example using archiso:
 sudo mkarchiso -v .
 # or if you use a custom script:
-./build.sh
+./xanados-iso/build.sh    # or ./build.sh for compatibility
 ```
 
 The generated ISO will appear in the `out/` directory by default.

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WORK_DIR=${WORK_DIR:-work}
-OUT_DIR=${OUT_DIR:-out}
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-PROFILE_DIR="$SCRIPT_DIR/xanados-iso"
-
-mkdir -p "$WORK_DIR" "$OUT_DIR"
-
-echo "[XanadOS] Building ISO..."
-mkarchiso -v -w "$WORK_DIR" -o "$OUT_DIR" "$PROFILE_DIR"
-
-echo "[XanadOS] Build complete. ISO is in $OUT_DIR"
-
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/xanados-iso/build.sh" "$@"

--- a/var/logs/codex/Codex-Core_20250608_201322.json
+++ b/var/logs/codex/Codex-Core_20250608_201322.json
@@ -1,0 +1,9 @@
+{
+  "timestamp": "2025-06-08T20:13:22Z",
+  "task_description": "Unify ISO build scripts and update docs",
+  "files_modified": ["build.sh", "xanados-iso/build.sh", "README.md", ".github/workflows/ci.yml"],
+  "validation_results": "shellcheck: pass; bats: pass; markdownlint: fail",
+  "outcome": "SUCCESS",
+  "commit_id": null,
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_201322.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_201322.log.txt
@@ -1,0 +1,1 @@
+[2025-06-08 20:13:22] Codex-Core: Unified build scripts. shellcheck and bats passed. markdownlint had existing issues.


### PR DESCRIPTION
## Summary
- point docs to `xanados-iso/build.sh`
- wrap root `build.sh` to call canonical script
- update CI to lint `xanados-iso/build.sh`
- add Codex log

## Testing
- `shellcheck build.sh xanados-iso/build.sh`
- `shfmt -d build.sh xanados-iso/build.sh`
- `bats var/tests`
- `markdownlint README.md` *(fails: line length and formatting)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee16a6e0832f9fcff5ec329155d6