### PR TITLE
core: enable strict mode in helper scripts

### DIFF
--- a/var/logs/codex/Codex-Core_20250608_201243.json
+++ b/var/logs/codex/Codex-Core_20250608_201243.json
@@ -1,0 +1,13 @@
+{
+  "timestamp": "20250608_201243",
+  "task_description": "Enable strict mode in helper scripts",
+  "files_modified": [
+    "xanados-iso/airootfs/usr/local/bin/choose-mirror",
+    "xanados-iso/airootfs/usr/local/bin/livecd-sound",
+    "xanados-iso/airootfs/usr/local/bin/pacman"
+  ],
+  "validation_results": "shellcheck warnings: choose-mirror SC2162; others clean",
+  "outcome": "SUCCESS",
+  "commit_id": "e74dbb2ee274381fa7f54fec33f3701d1734ec97",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_201243.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_201243.log.txt
@@ -1,0 +1,1 @@
+[20250608_201243] Codex-Core: Enabled strict mode in helper scripts. Validation: shellcheck run; warning on choose-mirror, others clean. Outcome: SUCCESS.

--- a/xanados-iso/airootfs/usr/local/bin/choose-mirror
+++ b/xanados-iso/airootfs/usr/local/bin/choose-mirror
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/xanados-iso/airootfs/usr/local/bin/livecd-sound
+++ b/xanados-iso/airootfs/usr/local/bin/livecd-sound
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/xanados-iso/airootfs/usr/local/bin/pacman
+++ b/xanados-iso/airootfs/usr/local/bin/pacman
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Wrapper script to prefer paru for package operations
 if command -v paru >/dev/null 2>&1; then
     exec paru "$@"


### PR DESCRIPTION
## Summary
- enable bash strict mode in various helper scripts
- log the change

## Testing
- `shellcheck xanados-iso/airootfs/usr/local/bin/choose-mirror`
- `shellcheck xanados-iso/airootfs/usr/local/bin/livecd-sound`
- `shellcheck xanados-iso/airootfs/usr/local/bin/pacman`
- `bats var/tests`


------
https://chatgpt.com/codex/tasks/task_e_6845ee2669cc832f8c0d51b8d9b8a4d7