### PR TITLE
Add changelog for last 50 commits

### DIFF
--- a/var/logs/codex/Codex-Core_20250608_202350.json
+++ b/var/logs/codex/Codex-Core_20250608_202350.json
@@ -1,0 +1,13 @@
+{
+  "timestamp": "20250608_202350",
+  "task_description": "Create changelog of last 50 commits",
+  "files_modified": [
+    "var/logs/codex/last_50_commits_changelog.txt",
+    "var/logs/codex/Codex-Core_20250608_202350.json",
+    "var/logs/codex/Codex-Core_20250608_202350.log.txt"
+  ],
+  "validation_results": "bats tests: 2 passed",
+  "outcome": "SUCCESS",
+  "commit_id": "f078151014f18f362bbfca833e91af28ab046d62",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_202350.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_202350.log.txt
@@ -1,0 +1,1 @@
+[20250608_202350] Codex-Core: Created changelog of last 50 commits. Validation: bats tests passed. Outcome: SUCCESS.

--- a/var/logs/codex/last_50_commits_changelog.txt
+++ b/var/logs/codex/last_50_commits_changelog.txt
@@ -1,0 +1,50 @@
+2325ca9 Merge pull request #127 from asafelobotomy/codex/enable-strict-mode-in-helper-scripts
+c0943cc log: record strict mode update
+00bdcdd Merge pull request #126 from asafelobotomy/codex/consolidate-build-scripts
+7a120b2 core: remove duplicate build script
+1f597de Merge pull request #125 from asafelobotomy/codex/update-test-command-in-readme.md
+dd26222 docs: update test command path
+a728c93 Merge pull request #124 from asafelobotomy/codex/update-ci-workflow-to-run-bats-from-var/tests
+7e4b068 fix(ci): run bats from var/tests
+3ad1195 Merge pull request #123 from asafelobotomy/codex/add-clamav.conf-and-rkhunter.conf
+45bfb60 Merge branch 'main' into codex/add-clamav.conf-and-rkhunter.conf
+dbab60f Update AGENTS.md
+4fdfc10 Add default security configs
+ea747cb Add files via upload
+162442c Update AGENTS.md
+4c9a19e Merge pull request #122 from asafelobotomy/codex/add-minimal-user-dotfiles-and-theme-placeholder
+45eb980 Merge branch 'main' into codex/add-minimal-user-dotfiles-and-theme-placeholder
+7a11818 Add skel dotfiles and theme placeholder
+4ec71ed Merge pull request #121 from asafelobotomy/codex/add-install_gaming.sh-and-update-agents.md
+99ef0db Document gaming package directory
+7a7a62a Update AGENTS.md
+c89d1de Update AGENTS.md
+3b0813a Update AGENTS.md
+b84116a Update AGENTS.md
+7dfe232 Update AGENTS.md
+99b8549 Merge pull request #120 from asafelobotomy/codex/check-and-create-missing-scripts
+2dd8416 Add missing ISO build script
+09e722a Update AGENTS.md
+cd8546e Merge pull request #119 from asafelobotomy/codex/add-popular-browsers-and-update-installation-script
+b7bb6c3 Add browser options
+2cb1e5c AGENTS.md
+7edc023 updating file structure
+f8d2770 Add files via upload
+2a83ded Merge pull request #118 from asafelobotomy/codex/add-qemu,-libvirt,-btrfs-assistant,-flatpak-builder
+60ccdb1 Add virtualization and packaging tools
+3f4b632 Add files via upload
+a777592 Merge pull request #117 from asafelobotomy/codex/replace-network-manager-applet-with-plasma-nm
+e48f236 Replace network-manager-applet with plasma-nm
+bdd9b0e Merge pull request #116 from asafelobotomy/codex/replace-7zip-with-p7zip
+57f7a92 Replace 7zip with p7zip
+231271a Merge pull request #115 from asafelobotomy/codex/update-ci-workflow-with-shellcheck
+d059051 ci: lint more shell scripts
+5e80233 Merge pull request #114 from asafelobotomy/codex/modify-run_cmd-in-common.sh
+8d350ad feat: improve run_cmd handling
+46de34b Merge pull request #113 from asafelobotomy/codex/set-log_dir-in-tests-and-verify-modes
+544cd80 Merge branch 'main' into codex/set-log_dir-in-tests-and-verify-modes
+e0749b5 fix logging dir and update tests
+c33ae92 Merge pull request #112 from asafelobotomy/codex/update-init_logging-to-handle-log_dir
+47f7845 refactor(logging): init logging dir lazily
+8be7caa Merge pull request #110 from asafelobotomy/codex/enhance-script-robustness-and-ci
+c2eba09 Fix shellcheck path for install scripts


### PR DESCRIPTION
## Summary
- capture last 50 git commits and store them in `var/logs/codex/last_50_commits_changelog.txt`
- log action with standard JSON and human log files

## Testing
- `bats var/tests/common.bats`

------
https://chatgpt.com/codex/tasks/task_e_6845f0f88eec832f894a35c5d41b1e55