### PR TITLE
Update shellcheck paths in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ jobs:
       - name: Lint shell scripts
         run: |
           shellcheck \
+            xanados-iso/airootfs/usr/local/bin/choose-mirror \
+            xanados-iso/airootfs/usr/local/bin/livecd-sound \
+            xanados-iso/airootfs/usr/local/bin/pacman \
             xanados-iso/airootfs/etc/xanados/scripts/*.sh \
             xanados-iso/calamares/scripts/*.sh \
             xanados-iso/calamares/modules/**/*.sh \
-            xanados-iso/airootfs/usr/local/bin/*.sh \
             xanados-iso/build.sh
       - name: Run tests
         run: bats var/tests

--- a/var/logs/codex/Codex-LintOps_20250608_202520.json
+++ b/var/logs/codex/Codex-LintOps_20250608_202520.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": "2025-06-08T20:25:20Z",
+  "task_description": "Replace wildcard with explicit script paths in CI",
+  "files_modified": [".github/workflows/ci.yml"],
+  "validation_results": "bats tests passed",
+  "outcome": "SUCCESS"
+}

--- a/var/logs/codex/Codex-LintOps_20250608_202520.log.txt
+++ b/var/logs/codex/Codex-LintOps_20250608_202520.log.txt
@@ -1,0 +1,1 @@
+[2025-06-08 20:25:20Z] Codex-LintOps: Replaced wildcard with explicit script paths in CI. Validation: bats tests passed. Outcome: SUCCESS.


### PR DESCRIPTION
## Summary
- expand shellcheck paths in workflow to include scripts without `.sh` extensions
- log the CI update in codex logs

## Testing
- `shellcheck xanados-iso/airootfs/usr/local/bin/choose-mirror xanados-iso/airootfs/usr/local/bin/livecd-sound xanados-iso/airootfs/usr/local/bin/pacman xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh xanados-iso/calamares/modules/**/*.sh xanados-iso/build.sh`
- `bats var/tests`

------
https://chatgpt.com/codex/tasks/task_e_6845f12879a4832f88555bcef0ad46fe