### PR TITLE
Run markdownlint on docs

### DIFF
--- a/var/logs/codex/Codex-Docs_20250608_204620.json
+++ b/var/logs/codex/Codex-Docs_20250608_204620.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": "2025-06-08T20:46:20Z",
+  "task_description": "Run markdownlint on documentation files",
+  "files_modified": [],
+  "validation_results": "markdownlint reported issues",
+  "outcome": "FAIL"
+}

--- a/var/logs/codex/Codex-Docs_20250608_204620.log.txt
+++ b/var/logs/codex/Codex-Docs_20250608_204620.log.txt
@@ -1,0 +1,1 @@
+[2025-06-08T20:46:20Z] Codex-Docs: Ran markdownlint on documentation files. Validation: markdownlint reported issues. Outcome: FAIL.


### PR DESCRIPTION
## Summary
- run markdownlint across repo docs
- log the results for Codex-Docs

## Testing
- `npx markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_6845f637b2d8832f833a674cb0b59771