### PR TITLE
Fix read command in choose-mirror

### DIFF
--- a/var/logs/codex/Codex-Core_20250608_212455.json
+++ b/var/logs/codex/Codex-Core_20250608_212455.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "20250608_212455",
+  "task_description": "Add -r to read command in choose-mirror",
+  "files_modified": [
+    "xanados-iso/airootfs/usr/local/bin/choose-mirror"
+  ],
+  "validation_results": "shellcheck clean; bats tests passed",
+  "outcome": "SUCCESS",
+  "commit_id": "6374a7841476b3846f6c980cc72aeb647a782039",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_212455.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_212455.log.txt
@@ -1,0 +1,1 @@
+[20250608_212455] Codex-Core: Added -r to read command in choose-mirror. Validation: shellcheck clean; bats tests passed. Outcome: SUCCESS.

--- a/xanados-iso/airootfs/usr/local/bin/choose-mirror
+++ b/xanados-iso/airootfs/usr/local/bin/choose-mirror
@@ -34,7 +34,7 @@ if [[ -z "$mirror" ]]; then
         echo "$(date +'%F %T') - No mirror specified, using default mirrorlist" >> "$log_file"
         exit 0
     else
-        read -p "Enter mirror URL: " mirror < /dev/tty
+        read -r -p "Enter mirror URL: " mirror < /dev/tty
         if [[ -z "$mirror" ]]; then
             echo "$(date +'%F %T') - No mirror provided, exiting" >> "$log_file"
             exit 1


### PR DESCRIPTION
## Summary
- add `-r` to the interactive `read` in choose-mirror
- log the update to Codex logs

## Testing
- `shellcheck xanados-iso/airootfs/usr/local/bin/choose-mirror`
- `bats var/tests`


------
https://chatgpt.com/codex/tasks/task_e_6845ff342364832fb273cbdd8a101851