### PR TITLE
Ensure read uses -r in choose-mirror

### DIFF
--- a/var/logs/codex/Codex-Core_20250608_212534.json
+++ b/var/logs/codex/Codex-Core_20250608_212534.json
@@ -1,0 +1,9 @@
+{
+  "timestamp": "20250608_212534",
+  "task_description": "Add -r to read in choose-mirror",
+  "files_modified": ["xanados-iso/airootfs/usr/local/bin/choose-mirror"],
+  "validation_results": "shellcheck: pass; bats: 2 passed",
+  "outcome": "SUCCESS",
+  "commit_id": "08bf005c6d14deaf74dfa545fa92d96dc796a36a",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_212534.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_212534.log.txt
@@ -1,0 +1,1 @@
+[20250608_212534] Codex-Core: Added -r flag to read in choose-mirror. Validation: shellcheck clean; bats passed. Outcome: SUCCESS.

--- a/xanados-iso/airootfs/usr/local/bin/choose-mirror
+++ b/xanados-iso/airootfs/usr/local/bin/choose-mirror
@@ -34,7 +34,7 @@ if [[ -z "$mirror" ]]; then
         echo "$(date +'%F %T') - No mirror specified, using default mirrorlist" >> "$log_file"
         exit 0
     else
-        read -p "Enter mirror URL: " mirror < /dev/tty
+        read -r -p "Enter mirror URL: " mirror < /dev/tty
         if [[ -z "$mirror" ]]; then
             echo "$(date +'%F %T') - No mirror provided, exiting" >> "$log_file"
             exit 1


### PR DESCRIPTION
## Summary
- enforce `read -r` in `choose-mirror`
- log automation run

## Testing
- `bats var/tests`
- `shellcheck xanados-iso/airootfs/usr/local/bin/choose-mirror`


------
https://chatgpt.com/codex/tasks/task_e_6845ff3b1e6c832f83702e8dcf1c53a4