### PR TITLE
Replace qemu with qemu-desktop

### DIFF
--- a/var/logs/codex/Codex-Core_20250608_222810.json
+++ b/var/logs/codex/Codex-Core_20250608_222810.json
@@ -1,0 +1,9 @@
+{
+  "timestamp": "20250608_222810",
+  "task_description": "Replace qemu with qemu-desktop package",
+  "files_modified": ["xanados-iso/packages.x86_64"],
+  "validation_results": "shellcheck: 2 warnings; bats: 2 passed",
+  "outcome": "SUCCESS",
+  "commit_id": "d56dd084e28f4be1ef9ccf003bd44b18d62a1973",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_222810.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_222810.log.txt
@@ -1,0 +1,1 @@
+[20250608_222810] Codex-Core: Replaced qemu with qemu-desktop. Validation: shellcheck warnings; bats passed. Outcome: SUCCESS.

--- a/xanados-iso/packages.x86_64
+++ b/xanados-iso/packages.x86_64
@@ -73,7 +73,7 @@ fuse3
 gvfs
 gvfs-smb
 gvfs-nfs
-qemu
+qemu-desktop
 libvirt
 qemu-guest-agent
 virt-manager


### PR DESCRIPTION
## Summary
- use `qemu-desktop` instead of `qemu` in ISO package list
- log the change

## Testing
- `shellcheck xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh`
- `bats var/tests/common.bats`


------
https://chatgpt.com/codex/tasks/task_e_68460d9a22cc832fb829fc343c25f09d