### PR TITLE
Add repo build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ If you encounter build or installation issues:
 - Consult the `var/bugs/README.md` for troubleshooting tips and to log reproducible bugs.
 - Search [GitHub Issues](https://github.com/asafelobotomy/xanados/issues) for similar problems.
 - If the problem persists, open a new issue with detailed steps to reproduce and attach relevant logs.
-- If pacman reports missing packages from the local repo, rebuild the repository
-  database as described in [docs/package-policy.md](docs/package-policy.md).
+ - If pacman reports missing packages from the local repo, rebuild the repository
+   database as described in [docs/package-policy.md](docs/package-policy.md).
+ - To extract packaged archives and refresh the repo automatically, run
+   `xanados-iso/packages/build_repo.sh` before building the ISO.
 
 ---
 

--- a/docs/package-policy.md
+++ b/docs/package-policy.md
@@ -38,5 +38,9 @@ packages:
 
 4. Commit the new package files and updated database.
 
+5. If the repository contains compressed archives instead of package files,
+   run `xanados-iso/packages/build_repo.sh` to extract them and rebuild the
+   database automatically.
+
 Keep the repository small and only include packages required by the ISO or
 installer scripts. Remove outdated packages to avoid bloat.

--- a/var/logs/codex/Codex-Core_20250608_225433.json
+++ b/var/logs/codex/Codex-Core_20250608_225433.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "20250608_225433",
+  "task_description": "Add script for building local repo from compressed archives",
+  "files_modified": [
+    "xanados-iso/packages/build_repo.sh",
+    "README.md",
+    "docs/package-policy.md",
+    "xanados-iso/packages/repo/README.md"
+  ],
+  "validation_results": "shellcheck: clean; bats: 2 passed",
+  "outcome": "SUCCESS",
+  "commit_id": "231f965471b553aabd3d91240936dd96206d39e9",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_225433.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_225433.log.txt
@@ -1,0 +1,1 @@
+[20250608_225433] Codex-Core: Added build_repo.sh script and updated docs. Validation: shellcheck clean; bats passed. Outcome: SUCCESS.

--- a/xanados-iso/packages/build_repo.sh
+++ b/xanados-iso/packages/build_repo.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the local package repository from compressed archives.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${SCRIPT_DIR}/repo"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "[INFO] Extracting packages to $REPO_DIR" >&2
+
+shopt -s nullglob
+for archive in "$REPO_DIR"/*.tar.gz "$REPO_DIR"/*.zip; do
+    [ -e "$archive" ] || continue
+    case "$archive" in
+        *.tar.gz)
+            tar -xzf "$archive" -C "$TMP_DIR" ;;
+        *.zip)
+            unzip -q "$archive" -d "$TMP_DIR" ;;
+    esac
+    echo "[INFO] Processed $archive" >&2
+done
+shopt -u nullglob
+
+if ls "$TMP_DIR"/*.pkg.tar.* >/dev/null 2>&1; then
+    mv "$TMP_DIR"/*.pkg.tar.* "$REPO_DIR"/
+fi
+
+cd "$REPO_DIR"
+if ls ./*.pkg.tar.zst >/dev/null 2>&1; then
+    repo-add -q xanados.db.tar.gz ./*.pkg.tar.zst
+    repo-add -q xanados.files.tar.gz ./*.pkg.tar.zst
+    echo "[INFO] Repository database updated" >&2
+else
+    echo "[WARN] No package files found" >&2
+fi

--- a/xanados-iso/packages/repo/README.md
+++ b/xanados-iso/packages/repo/README.md
@@ -8,3 +8,5 @@ The following packages are provided:
 - paru
 
 Place the package files (*.pkg.tar.zst) here before building the ISO.
+If only compressed archives are present, run `../build_repo.sh` to extract them
+and regenerate the repository database.


### PR DESCRIPTION
## Summary
- add script to extract compressed packages and refresh the local repo
- document repo build script usage in docs and README
- log Codex-Core execution

## Testing
- `shellcheck xanados-iso/packages/build_repo.sh`
- `bats var/tests`


------
https://chatgpt.com/codex/tasks/task_e_684613c503f0832f98c74e284585e96a