### PR TITLE
Remove opera and preload references

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fixes/               # Patches/bugfixes
 - **Security Tools Out-of-the-Box**: Includes essential security packages.
 - **Performance Tweaks**: Ships with tools to optimize system responsiveness and battery life.
 - **Gamer-Ready**: Custom gaming stack installer lets you pick only what you want.
-- **Built-in Repo**: Prebuilt AUR packages (`btrfs-assistant`, `brave`, `opera`, `preload`, `paru`) are included via `xanados-iso/packages/repo`.
+- **Built-in Repo**: Prebuilt AUR packages (`btrfs-assistant`, `brave`, `paru`) are included via `xanados-iso/packages/repo`.
 
 ---
 
@@ -56,7 +56,6 @@ fixes/               # Patches/bugfixes
 - `thermald` — CPU thermal protection
 - `cpupower` — CPU frequency scaling
 - `irqbalance` — IRQ distribution
-- `preload` — Adaptive readahead daemon (from the built-in repo)
 - `earlyoom` — Early Out of Memory killer
 
 ### Notable Extras

--- a/var/logs/codex/Codex-Docs_20250608_225931.json
+++ b/var/logs/codex/Codex-Docs_20250608_225931.json
@@ -1,0 +1,13 @@
+{
+  "timestamp": "2025-06-08T22:59:38Z",
+  "task_description": "Remove references to Opera and preload packages",
+  "files_modified": [
+    "README.md",
+    "xanados-iso/packages/repo/README.md",
+    "xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh",
+    "xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh",
+    "xanados-iso/airootfs/etc/xanados/welcome.py"
+  ],
+  "validation_results": "shellcheck clean; bats tests passed",
+  "outcome": "SUCCESS"
+}

--- a/var/logs/codex/Codex-Docs_20250608_225931.log.txt
+++ b/var/logs/codex/Codex-Docs_20250608_225931.log.txt
@@ -1,0 +1,1 @@
+[2025-06-08 22:59:39Z] Codex-Docs: Removed references to Opera and preload packages. Validation: shellcheck clean; bats tests passed. Outcome: SUCCESS.

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_gaming.sh
@@ -3,7 +3,7 @@
 source "$(dirname "$0")/common.sh"
 init_logging install_gaming
 
-# Prebuilt packages from xanados-iso/packages/repo include btrfs-assistant, brave, opera, preload, and paru.
+# Prebuilt packages from xanados-iso/packages/repo include btrfs-assistant, brave, and paru.
 DRY_RUN=false
 REMOVE=false
 POSITIONAL=()

--- a/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
+++ b/xanados-iso/airootfs/etc/xanados/scripts/install_recommended.sh
@@ -3,7 +3,7 @@
 source "$(dirname "$0")/common.sh"
 init_logging install_recommended
 
-# Prebuilt packages from xanados-iso/packages/repo include btrfs-assistant, brave, opera, preload, and paru.
+# Prebuilt packages from xanados-iso/packages/repo include btrfs-assistant, brave, and paru.
 DRY_RUN=false
 BROWSER="brave"
 while [[ $# -gt 0 ]]; do

--- a/xanados-iso/airootfs/etc/xanados/welcome.py
+++ b/xanados-iso/airootfs/etc/xanados/welcome.py
@@ -158,7 +158,6 @@ class WelcomeApp(QtWidgets.QWidget):
             "Chromium": "chromium",
             "Vivaldi": "vivaldi",
             "Tor Browser": "torbrowser-launcher",
-            "Opera": "opera",
         }
         browser_layout = QtWidgets.QHBoxLayout()
         browser_label = QtWidgets.QLabel("Web Browser:")

--- a/xanados-iso/packages/repo/README.md
+++ b/xanados-iso/packages/repo/README.md
@@ -3,8 +3,6 @@ The following packages are provided:
 
 - btrfs-assistant
 - brave
-- opera
-- preload
 - paru
 
 Place the package files (*.pkg.tar.zst) here before building the ISO.


### PR DESCRIPTION
## Summary
- strip Opera and preload mentions from docs and scripts
- adjust browser options in welcome script
- log changes in `var/logs/codex`

## Testing
- `shellcheck xanados-iso/airootfs/usr/local/bin/choose-mirror xanados-iso/airootfs/usr/local/bin/livecd-sound xanados-iso/airootfs/usr/local/bin/pacman xanados-iso/airootfs/etc/xanados/scripts/*.sh xanados-iso/calamares/scripts/*.sh xanados-iso/calamares/modules/**/*.sh xanados-iso/build.sh`
- `bats var/tests`

------
https://chatgpt.com/codex/tasks/task_e_6846154624c4832f8137a835e9cbf925