### PR TITLE
Use PKGBUILD archives for local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fixes/               # Patches/bugfixes
 - **Security Tools Out-of-the-Box**: Includes essential security packages.
 - **Performance Tweaks**: Ships with tools to optimize system responsiveness and battery life.
 - **Gamer-Ready**: Custom gaming stack installer lets you pick only what you want.
-- **Built-in Repo**: Prebuilt AUR packages (`btrfs-assistant`, `brave`, `paru`) are included via `xanados-iso/packages/repo`.
+- **Built-in Repo**: AUR archives (`btrfs-assistant`, `brave`, `paru`) live in `xanados-iso/packages/repo` and are built automatically.
 
 ---
 
@@ -109,7 +109,7 @@ If you encounter build or installation issues:
 - If the problem persists, open a new issue with detailed steps to reproduce and attach relevant logs.
  - If pacman reports missing packages from the local repo, rebuild the repository
    database as described in [docs/package-policy.md](docs/package-policy.md).
- - To extract packaged archives and refresh the repo automatically, run
+ - To build the AUR archives and refresh the repo automatically, run
    `xanados-iso/packages/build_repo.sh` before building the ISO.
 
 ---

--- a/docs/package-policy.md
+++ b/docs/package-policy.md
@@ -16,31 +16,18 @@ packages to keep maintenance overhead low.
 
 ## Maintaining the Local Repository
 
-Prebuilt AUR packages live under `xanados-iso/packages/repo/`. To add or update
+Prebuilt AUR tarballs live under `xanados-iso/packages/repo/`. To add or update
 packages:
 
-1. On an Arch-based system, clone the package's PKGBUILD and build it:
+1. Download the package's AUR tarball (e.g. via `paru -G <package>` or from the
+   AUR website) and place the resulting `*.tar.gz` archive in
+   `xanados-iso/packages/repo/`.
 
-   ```bash
-   git clone <aur-url>
-   cd <package>
-   makepkg -s
-   ```
+2. Run `xanados-iso/packages/build_repo.sh` to build the packages and refresh
+   the repository database. The script extracts each archive, runs `makepkg`, and
+   adds the resulting `*.pkg.tar.zst` files to the repo.
 
-2. Copy the resulting `*.pkg.tar.zst` file(s) into `xanados-iso/packages/repo/`.
-
-3. From inside that directory, update the repository database:
-
-   ```bash
-   repo-add xanados.db.tar.gz *.pkg.tar.zst
-   repo-add xanados.files.tar.gz *.pkg.tar.zst
-   ```
-
-4. Commit the new package files and updated database.
-
-5. If the repository contains compressed archives instead of package files,
-   run `xanados-iso/packages/build_repo.sh` to extract them and rebuild the
-   database automatically.
+3. Commit the updated package files and repository database.
 
 Keep the repository small and only include packages required by the ISO or
 installer scripts. Remove outdated packages to avoid bloat.

--- a/var/logs/codex/Codex-Core_20250608_230454.json
+++ b/var/logs/codex/Codex-Core_20250608_230454.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "20250608_230454",
+  "task_description": "Update repo builder to use AUR PKGBUILD tarballs",
+  "files_modified": [
+    "xanados-iso/packages/build_repo.sh",
+    "README.md",
+    "docs/package-policy.md",
+    "xanados-iso/packages/repo/README.md"
+  ],
+  "validation_results": "shellcheck clean; bats tests pass",
+  "outcome": "SUCCESS",
+  "commit_id": "e69b4b034361d92183a24b9e71f21ba9773088b8",
+  "branch": "work"
+}

--- a/var/logs/codex/Codex-Core_20250608_230454.log.txt
+++ b/var/logs/codex/Codex-Core_20250608_230454.log.txt
@@ -1,0 +1,1 @@
+[20250608_230454] Codex-Core: Updated build_repo.sh for PKGBUILD archives and refreshed docs. Validation: shellcheck clean; bats passed. Outcome: SUCCESS.

--- a/xanados-iso/packages/build_repo.sh
+++ b/xanados-iso/packages/build_repo.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build the local package repository from compressed archives.
+# Build the local package repository from compressed AUR archives.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="${SCRIPT_DIR}/repo"
+# Temporary working directory for extracting and building packages
 TMP_DIR="$(mktemp -d)"
 
 cleanup() {
@@ -11,23 +12,31 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "[INFO] Extracting packages to $REPO_DIR" >&2
+echo "[INFO] Building packages into $REPO_DIR" >&2
 
 shopt -s nullglob
 for archive in "$REPO_DIR"/*.tar.gz "$REPO_DIR"/*.zip; do
     [ -e "$archive" ] || continue
+    pkgdir="$TMP_DIR/$(basename "${archive%.*.*}")"
+    mkdir -p "$pkgdir"
     case "$archive" in
         *.tar.gz)
-            tar -xzf "$archive" -C "$TMP_DIR" ;;
+            tar -xzf "$archive" -C "$pkgdir" ;;
         *.zip)
-            unzip -q "$archive" -d "$TMP_DIR" ;;
+            unzip -q "$archive" -d "$pkgdir" ;;
     esac
-    echo "[INFO] Processed $archive" >&2
+    echo "[INFO] Extracted $archive" >&2
+    if [[ -f "$pkgdir/PKGBUILD" ]]; then
+        echo "[INFO] Building $(basename "$archive")" >&2
+        (cd "$pkgdir" && makepkg -s --noconfirm --noprogressbar)
+    fi
 done
 shopt -u nullglob
 
-if ls "$TMP_DIR"/*.pkg.tar.* >/dev/null 2>&1; then
-    mv "$TMP_DIR"/*.pkg.tar.* "$REPO_DIR"/
+# Move any built packages from the temp directory back to the repo
+if ls "$TMP_DIR"/*.pkg.tar.* "$TMP_DIR"/*/*.pkg.tar.* >/dev/null 2>&1; then
+    mv "$TMP_DIR"/*/*.pkg.tar.* "$REPO_DIR"/ 2>/dev/null || true
+    mv "$TMP_DIR"/*.pkg.tar.* "$REPO_DIR"/ 2>/dev/null || true
 fi
 
 cd "$REPO_DIR"

--- a/xanados-iso/packages/repo/README.md
+++ b/xanados-iso/packages/repo/README.md
@@ -1,10 +1,9 @@
-This directory holds prebuilt AUR packages included with the ISO.
+This directory holds AUR package tarballs that will be built for the ISO.
 The following packages are provided:
 
 - btrfs-assistant
 - brave
 - paru
 
-Place the package files (*.pkg.tar.zst) here before building the ISO.
-If only compressed archives are present, run `../build_repo.sh` to extract them
-and regenerate the repository database.
+Place the package tarballs (`*.tar.gz`) here before building the ISO.
+Run `../build_repo.sh` to build them and regenerate the repository database.


### PR DESCRIPTION
## Summary
- build_repo.sh now builds packages from AUR PKGBUILD tarballs
- update README and docs with new workflow
- refresh repo README
- log update in codex logs

## Testing
- `shellcheck xanados-iso/packages/build_repo.sh`
- `bats var/tests`


------
https://chatgpt.com/codex/tasks/task_e_6846167e8404832fa3251d2ef995a64c